### PR TITLE
Fix issue with specifying username when configuring Banyan

### DIFF
--- a/Banyan/src/utils.jl
+++ b/Banyan/src/utils.jl
@@ -138,7 +138,7 @@ function configure(; kwargs...)
 
     # Load arguments
     kwargs = Dict(kwargs)
-    username = if_in_or(:username, kwargs)
+    # username = if_in_or(:username, kwargs)
     user_id = if_in_or(:user_id, kwargs)
     api_key = if_in_or(:api_key, kwargs)
     ec2_key_pair_name = if_in_or(:ec2_key_pair_name, kwargs)
@@ -152,9 +152,9 @@ function configure(; kwargs...)
     if isnothing(api_key) && haskey(ENV, "BANYAN_API_KEY")
         api_key = ENV["BANYAN_API_KEY"]
     end
-    if isnothing(username) && haskey(ENV, "BANYAN_USERNAME")
-        api_key = ENV["BANYAN_USERNAME"]
-    end
+    # if isnothing(username) && haskey(ENV, "BANYAN_USERNAME")
+    #     api_key = ENV["BANYAN_USERNAME"]
+    # end
 
     # Check banyanconfig file
     if isnothing(user_id) && haskey(banyan_config, "banyan") && haskey(banyan_config["banyan"], "user_id")
@@ -163,9 +163,9 @@ function configure(; kwargs...)
     if isnothing(api_key) && haskey(banyan_config, "banyan") && haskey(banyan_config["banyan"], "api_key")
         api_key = banyan_config["banyan"]["api_key"]
     end
-    if isnothing(username) && haskey(banyan_config, "banyan") && haskey(banyan_config["banyan"], "username")
-        username = banyan_config["banyan"]["username"]
-    end
+    # if isnothing(username) && haskey(banyan_config, "banyan") && haskey(banyan_config["banyan"], "username")
+    #     username = banyan_config["banyan"]["username"]
+    # end
 
     # Initialize
     is_modified = false
@@ -187,11 +187,11 @@ function configure(; kwargs...)
     end
 
     # Check for changes in required
-    if !isnothing(username) &&
-       (username != banyan_config["banyan"]["username"])
-        banyan_config["banyan"]["username"] = username
-        is_modified = true
-    end
+    # if !isnothing(username) &&
+    #    (username != banyan_config["banyan"]["username"])
+    #     banyan_config["banyan"]["username"] = username
+    #     is_modified = true
+    # end
     if !isnothing(user_id) &&
         (user_id != banyan_config["banyan"]["user_id"])
          banyan_config["banyan"]["user_id"] = user_id
@@ -201,10 +201,10 @@ function configure(; kwargs...)
         banyan_config["banyan"]["api_key"] = api_key
         is_modified = true
     end
-    if !isnothing(username) && (username != banyan_config["banyan"]["username"])
-        banyan_config["banyan"]["username"] = username
-        is_modified = true
-    end
+    # if !isnothing(username) && (username != banyan_config["banyan"]["username"])
+    #     banyan_config["banyan"]["username"] = username
+    #     is_modified = true
+    # end
 
     # Check for changes in potentially required
 

--- a/Banyan/src/utils.jl
+++ b/Banyan/src/utils.jl
@@ -146,21 +146,26 @@ function configure(; kwargs...)
         if_in_or(:require_ec2_key_pair_name, kwargs, false)
 
     # Check environment variables
-    if user_id == nothing && haskey(ENV, "BANYAN_USER_ID")
+    if isnothing(user_id) && haskey(ENV, "BANYAN_USER_ID")
         user_id = ENV["BANYAN_USER_ID"]
     end
-    if api_key == nothing && haskey(ENV, "BANYAN_API_KEY")
+    if isnothing(api_key) && haskey(ENV, "BANYAN_API_KEY")
         api_key = ENV["BANYAN_API_KEY"]
+    end
+    if isnothing(username) && haskey(ENV, "BANYAN_USERNAME")
+        api_key = ENV["BANYAN_USERNAME"]
     end
 
     # Check banyanconfig file
-    if user_id == nothing && haskey(banyan_config, "banyan") && haskey(banyan_config["banyan"], "user_id")
+    if isnothing(user_id) && haskey(banyan_config, "banyan") && haskey(banyan_config["banyan"], "user_id")
         user_id = banyan_config["banyan"]["user_id"]
     end
-    if api_key == nothing && haskey(banyan_config, "banyan") && haskey(banyan_config["banyan"], "api_key")
+    if isnothing(api_key) && haskey(banyan_config, "banyan") && haskey(banyan_config["banyan"], "api_key")
         api_key = banyan_config["banyan"]["api_key"]
     end
-    
+    if isnothing(username) && haskey(banyan_config, "banyan") && haskey(banyan_config["banyan"], "username")
+        username = banyan_config["banyan"]["username"]
+    end
 
     # Initialize
     is_modified = false
@@ -169,7 +174,7 @@ function configure(; kwargs...)
     # Ensure a configuration has been created or can be created. Otherwise,
     # return nothing
     if isnothing(banyan_config)
-        if !isnothing(user_id) && !isnothing(api_key)
+        if !isnothing(user_id) && !isnothing(api_key) && !isnothing(username)
             banyan_config = Dict(
                 "banyan" =>
                     Dict("username" => username, "user_id" => user_id, "api_key" => api_key),
@@ -177,7 +182,7 @@ function configure(; kwargs...)
             )
             is_modified = true
         else
-            error("User ID and API key not provided")
+            error("Your username, user ID, and API key must be specified using either keyword arguments, environment variables, or banyanconfig.toml")
         end
     end
 
@@ -194,6 +199,10 @@ function configure(; kwargs...)
      end
     if !isnothing(api_key) && (api_key != banyan_config["banyan"]["api_key"])
         banyan_config["banyan"]["api_key"] = api_key
+        is_modified = true
+    end
+    if !isnothing(username) && (username != banyan_config["banyan"]["username"])
+        banyan_config["banyan"]["username"] = username
         is_modified = true
     end
 


### PR DESCRIPTION
This adds a `BANYAN_USERNAME` environment variable and fixes an issue where an invalid TOML file would be created when username is not specified.