### PR TITLE
Fix sample collection for HDF5 datasets

### DIFF
--- a/Banyan/src/jobs.jl
+++ b/Banyan/src/jobs.jl
@@ -173,12 +173,11 @@ function destroy_job(job_id::JobId = get_job_id(); failed = nothing, force = fal
 
     # configure(; kwargs...)
 
-    @debug "Destroying job with ID $job_id"
+    @info "Destroying job with ID $job_id"
     send_request_get_response(
         :destroy_job,
         Dict{String,Any}("job_id" => job_id, "failed" => failed == true),
     )
-    @info "Destroyed job with ID $job_id"
 
     # Remove from global state
     if !isnothing(current_job_id) && get_job_id() == job_id
@@ -254,7 +253,6 @@ function destroy_all_jobs(cluster_name::String; kwargs...)
     jobs = get_jobs(cluster_name, status = "running")
     for (job_id, job) in jobs
         if job["status"] == "running"
-            @info "Destroying job id $job_id"
             destroy_job(job_id, kwargs...)
         end
     end

--- a/Banyan/src/locations.jl
+++ b/Banyan/src/locations.jl
@@ -288,10 +288,10 @@ Disk() = None() # The scheduler intelligently determines when to split from and 
 # overall data size. This way, two arrays that have the same actual size will
 # be guaranteed to have the same sample size.
 
-BANYAN_MAX_EXACT_SAMPLE_LENGTH = parse(Int, get(ENV, "BANYAN_MAX_EXACT_SAMPLE_LENGTH", "2048"))
+get_max_exact_sample_length() = parse(Int, get(ENV, "BANYAN_MAX_EXACT_SAMPLE_LENGTH", "2048"))
 
 getsamplenrows(totalnrows) =
-    if totalnrows <= BANYAN_MAX_EXACT_SAMPLE_LENGTH
+    if totalnrows <= get_max_exact_sample_length()
         # NOTE: This includes the case where the dataset is empty
         # (totalnrows == 0)
         totalnrows
@@ -480,7 +480,7 @@ function get_remote_hdf5_location(remotepath, hdf5_ending, remote_location=nothi
                     # dset_sample = dset[1:1, remainingcolons...][1:0, remainingcolons...]
                     # If the data is already shuffled or if we just want to
                     # take an exact sample, we don't need to randomly sample here.
-                    if datalength > BANYAN_MAX_EXACT_SAMPLE_LENGTH || shuffled
+                    if datalength > get_max_exact_sample_length() && !shuffled
                          sampleindices = randsubseq(1:datalength, 1 / get_job().sample_rate)
                         # sample = dset[sampleindices, remainingcolons...]
                         if !isempty(sampleindices)
@@ -503,10 +503,10 @@ function get_remote_hdf5_location(remotepath, hdf5_ending, remote_location=nothi
                     if size(dset_sample, 1) < samplelength
                         dset_sample = vcat(
                             dset_sample,
-                            dset[1:(samplelength-size(sample, 1)), remainingcolons...],
+                            dset[1:(samplelength-size(dset_sample, 1)), remainingcolons...],
                         )
                     else
-                        dset = dset[1:samplelength, remainingcolons...]
+                        dset_sample = dset[1:samplelength, remainingcolons...]
                     end
                 end
 
@@ -544,7 +544,7 @@ function get_remote_hdf5_location(remotepath, hdf5_ending, remote_location=nothi
     if isnothing(remote_sample)
         remote_sample = if isnothing(loc_for_reading)
             Sample()
-        elseif totalnrows <= BANYAN_MAX_EXACT_SAMPLE_LENGTH
+        elseif totalnrows <= get_max_exact_sample_length()
             ExactSample(dset_sample, total_memory_usage = nbytes)
         else
             Sample(dset_sample, total_memory_usage = nbytes)
@@ -570,6 +570,10 @@ function get_remote_table_location(remotepath, remote_location=nothing, remote_s
     # given directory (e.g., wildcards)
 
     # If !isnothing(remote_location), we make sure to not update nbytes, totalnrows, and files
+
+    # TODO: Fix issues:
+    # - Reusing remote location where the previous location was just used for writing
+    # - Reusing remote sample where the previous location was just used for writing
 
     nbytes = isnothing(remote_location) ? 0 : remote_location.nbytes
     totalnrows = isnothing(remote_location) ? 0 : remote_location.nrows
@@ -856,7 +860,7 @@ function get_remote_table_location(remotepath, remote_location=nothing, remote_s
             @show samplenrows
         end
         # If we already have enough rows in the exact sample...
-        if totalnrows <= BANYAN_MAX_EXACT_SAMPLE_LENGTH
+        if totalnrows <= get_max_exact_sample_length()
             randomsample = exactsample
         end
         # Regardless, expand the random sample as needed...
@@ -889,7 +893,7 @@ function get_remote_table_location(remotepath, remote_location=nothing, remote_s
     if isnothing(remote_sample)
         remote_sample = if isnothing(loc_for_reading)
             Sample()
-        elseif totalnrows <= BANYAN_MAX_EXACT_SAMPLE_LENGTH
+        elseif totalnrows <= get_max_exact_sample_length()
             ExactSample(randomsample, total_memory_usage = nbytes)
         else
             Sample(randomsample, total_memory_usage = nbytes)

--- a/Banyan/src/locations.jl
+++ b/Banyan/src/locations.jl
@@ -365,8 +365,10 @@ function Remote(p; shuffled=false, similar_files=false, location_invalid = false
         rm(locationpath, force=true, recursive=true)
     end
 
-    # Store sample in cache
-    if !invalidate_sample
+    # Store sample in cache. We don't store null samples because they are
+    # either samples for locations that don't exist yet (write-only) or are
+    # really cheap to collect the sample.
+    if !invalidate_sample && !isnothing(remote_sample.value)
         mkpath(samplespath)
         serialize(samplepath, remote_sample)
     else

--- a/Banyan/src/locations.jl
+++ b/Banyan/src/locations.jl
@@ -901,7 +901,7 @@ function get_remote_table_location(remotepath, remote_location=nothing, remote_s
     # Load metadata for writing
     # NOTE: `remotepath` should end with `.parquet` or `.csv` if Parquet
     # or CSV dataset is desired to be created
-    loc_for_writing, metadata_for_writing = ("Remote", Dict("path" => remotepath))
+    loc_for_writing, metadata_for_writing = ("Remote", Dict("path" => remotepath, "files" => [], "nrows" => 0, "nbytes" => 0))
 
     # TODO: Cache sample on disk
 

--- a/Banyan/src/partitions.jl
+++ b/Banyan/src/partitions.jl
@@ -71,6 +71,12 @@ ScaleBy(arg, factor::Real = 1.0, relative_to...) =
         pt_refs_to_jl([arg; relative_to...])
     )
 
+# Co, Cross, Equal, Sequential, Match, MatchOn, AtMost are PA-level constraints.
+# AtMost, ScaleBy are PT-level constraints.
+# For all constraints, contradictions result in the PA not being used. The
+# exception is ScaleBy constraints where multiple PAs can specify a ScaleBy
+# for the same PT and these are not fused in any way.
+
 # TODO: Make the above constraint constructors produce dictionaries that have
 # fields that make sense and are specialized for each one. This will reduce
 # a significant amount of messy and hard-to-read code here (e.g., what in the

--- a/Banyan/src/pt_lib_constructors.jl
+++ b/Banyan/src/pt_lib_constructors.jl
@@ -113,7 +113,8 @@ function Blocked(
             # Create `ScaleBy` constraints
             if b
                 push!(constraints.constraints, ScaleBy(f, 1.0))
-                # TODO: Add an AtMost constraint in the case that input elements are very large
+                # TODO: Add an AtMost constraint in the case that there are very few rows.
+                # That AtMost constraint would only go here in Blocked
             else
                 if !isnothing(filtered_from)
                     filtered_from = to_vector(filtered_from)

--- a/Banyan/src/pt_lib_constructors.jl
+++ b/Banyan/src/pt_lib_constructors.jl
@@ -202,6 +202,9 @@ function Grouped(
                 end
 
                 # Add constraints
+                # In the future if the element size can be really big (like a multi-dimensional array
+                # that is very wide or data frame with many columns), we may want to have a constraint
+                # where the partition size must be larger than that minimum element size.
                 push!(constraints.constraints, AtMost(max_ngroups, f))
                 push!(constraints.constraints, ScaleBy(f, 1.0))
 

--- a/Banyan/src/pt_lib_constructors.jl
+++ b/Banyan/src/pt_lib_constructors.jl
@@ -221,10 +221,10 @@ function Grouped(
                         fkey = fby[i]
 
                         # Compute the amount to scale memory usage by based on data skew
-                        min_filtered_to = sample(f, :statistics, fkey, :min)
-                        max_filtered_to = sample(f, :statistics, fkey, :max)
+                        min_filtered_to = sample(f, :statistics, key, :min)
+                        max_filtered_to = sample(f, :statistics, key, :max)
                         # divisions_filtered_from = sample(ff, :statistics, key, :divisions)
-                        ff_percentile = sample(ff, :statistics, key, :percentile, min_filtered_to, max_filtered_to)
+                        ff_percentile = sample(ff, :statistics, fkey, :percentile, min_filtered_to, max_filtered_to)
                         (1 / ff_percentile, filtered_from_futures)
                     end
                     push!(constraints.constraints, ScaleBy(f, factor, from))

--- a/Banyan/src/queues.jl
+++ b/Banyan/src/queues.jl
@@ -41,7 +41,7 @@ function receive_next_message(queue_name)
         # jobs[job_id].current_status = "failed"
         # set_job(nothing) # future usage of this job should immediately fail
         # delete!(jobs, job_id)
-        destroy_job() # This will reset the `current_job_id` and delete from `jobs`
+        destroy_job(failed=true) # This will reset the `current_job_id` and delete from `jobs`
         # TODO: Document why the 12 here is necessary
         # if is_debug_on()
             println(content[12:end])

--- a/Banyan/src/queues.jl
+++ b/Banyan/src/queues.jl
@@ -39,8 +39,9 @@ function receive_next_message(queue_name)
     elseif startswith(content, "JOB_FAILURE")
         @debug "Job failed"
         # jobs[job_id].current_status = "failed"
-        set_job(nothing) # future usage of this job should immediately fail
-        delete!(jobs, job_id)
+        # set_job(nothing) # future usage of this job should immediately fail
+        # delete!(jobs, job_id)
+        destroy_job() # This will reset the `current_job_id` and delete from `jobs`
         # TODO: Document why the 12 here is necessary
         # if is_debug_on()
             println(content[12:end])

--- a/Banyan/src/utils_pfs.jl
+++ b/Banyan/src/utils_pfs.jl
@@ -471,7 +471,7 @@ function getpath(path)
             # to a user, a short-term solution is to use a different
             # URL each time (e.g., add a dummy query to the end of the
             # URL)
-            download(path, joined_path)
+            Downloads.download(path, joined_path)
         end
         joined_path
     elseif startswith(path, "s3://")

--- a/Banyan/src/utils_s3fs.jl
+++ b/Banyan/src/utils_s3fs.jl
@@ -30,7 +30,7 @@ function download_remote_path(remotepath)
         # This will either return an `S3Path` still referring to a remote
         # location or it will return a local S3FS path for reading from.
     elseif startswith(remotepath, "http://") || startswith(remotepath, "https://")
-        download(remotepath, tempname() * splitext(remotepath)[2])
+        Downloads.download(remotepath, tempname() * splitext(remotepath)[2])
     else
         throw(
             ArgumentError(

--- a/Banyan/test/runtests.jl
+++ b/Banyan/test/runtests.jl
@@ -12,7 +12,8 @@ function destroy_all_jobs_for_testing()
     end
 end
 
-function use_job_for_testing(f::Function;
+function use_job_for_testing(
+    f::Function;
     sample_rate = 2,
     max_exact_sample_length = 50,
     with_s3fs = nothing,
@@ -101,7 +102,7 @@ function use_data(file_extension, remote_kind, single_file)
             (file_extension_is_hdf5 ? "fillval" : "iris") * ".$file_extension"
         testing_dataset_local_path =
             joinpath(homedir(), ".banyan", "testing_datasets", testing_dataset_local_name)
-            
+
         # Download if not already download
         if !isfile(testing_dataset_local_path)
             # Download to local ~/.banyan/testing_datasets

--- a/Banyan/test/runtests.jl
+++ b/Banyan/test/runtests.jl
@@ -6,8 +6,9 @@ global jobs_for_testing = Dict()
 
 function destroy_all_jobs_for_testing()
     global jobs_for_testing
-    for job_id in values(jobs_for_testing)
+    for (job_config_hash, job_id) in jobs_for_testing
         destroy_job(job_id)
+        delete!(jobs_for_testing, job_config_hash)
     end
 end
 
@@ -44,7 +45,7 @@ function use_job_for_testing(f::Function;
     )
 
     # If selected job has already failed, this will throw an error.
-    get_job()
+    jobs_for_testing[job_config_hash] = get_job_id()
 
     # Set the maximum exact sample length
     ENV["BANYAN_MAX_EXACT_SAMPLE_LENGTH"] = string(max_exact_sample_length)

--- a/Banyan/test/sample_collection.jl
+++ b/Banyan/test/sample_collection.jl
@@ -7,7 +7,7 @@
 # - Verify no error, length of returned sample, location files and their nrows,
 # (eventually) ensure that rows come from the right files
 @testset "$exact_or_inexact sample collected from $(titlecase(file_extension)) $(single_file ? "file" : "directory") on $on $with_or_without_s3fs S3FS with $optimization reusing $reusing" for exact_or_inexact in
-                                                                                                                                       [
+                                                                                                                                                                                                [
         "Exact",
         "Inexact",
     ],
@@ -75,7 +75,8 @@
 
         # Verify the sample
         sample_nrows =
-            contains(src_name, "h5") ? size(remote_location.sample.value, 1) : nrows(remote_location.sample.value)
+            contains(src_name, "h5") ? size(remote_location.sample.value, 1) :
+            nrows(remote_location.sample.value)
         if exact_or_inexact == "Exact"
             @test sample_nrows == src_nrows
         else

--- a/Banyan/test/sample_collection.jl
+++ b/Banyan/test/sample_collection.jl
@@ -6,7 +6,7 @@
 # - Test shuffled, similar files, default, invalidated location but reused sample or reused location
 # - Verify no error, length of returned sample, location files and their nrows,
 # (eventually) ensure that rows come from the right files
-@testset "$exact_or_inexact sample collected from $(titlecase(file_extension)) $(single_file ? "file" : "directory") on $on $with_or_without_s3fs S3FS  with $optimization reusing $reusing" for exact_or_inexact in
+@testset "$exact_or_inexact sample collected from $(titlecase(file_extension)) $(single_file ? "file" : "directory") on $on $with_or_without_s3fs S3FS with $optimization reusing $reusing" for exact_or_inexact in
                                                                                                                                        [
         "Exact",
         "Inexact",
@@ -74,9 +74,8 @@
         # TODO: Fix sample collection in the optimizations/reuse and nbytes
 
         # Verify the sample
-        @show src_name
         sample_nrows =
-            contains("h5", src_name) ? size(remote_location.sample.value, 1) : nrows(remote_location.sample.value)
+            contains(src_name, "h5") ? size(remote_location.sample.value, 1) : nrows(remote_location.sample.value)
         if exact_or_inexact == "Exact"
             @test sample_nrows == src_nrows
         else

--- a/BanyanArrays/Manifest.toml
+++ b/BanyanArrays/Manifest.toml
@@ -43,7 +43,7 @@ version = "1.2.0"
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [[Banyan]]
-deps = ["AWS", "AWSCore", "AWSS3", "AWSSQS", "Arrow", "Base64", "CSV", "DataFrames", "Downloads", "FileIO", "FilePathsBase", "HDF5", "HTTP", "IniFile", "IterTools", "JSON", "Parquet", "Random", "Serialization", "TOML", "TimeZones"]
+deps = ["AWS", "AWSCore", "AWSS3", "AWSSQS", "Arrow", "Base64", "CSV", "DataFrames", "Downloads", "FileIO", "FilePathsBase", "HDF5", "HTTP", "IniFile", "IterTools", "JSON", "MPI", "Parquet", "Random", "Serialization", "TOML", "TimeZones"]
 path = "../Banyan"
 uuid = "706d138b-e922-45b9-a636-baf8ae0d5317"
 version = "0.1.1"
@@ -111,6 +111,10 @@ git-tree-sha1 = "dc7dedc2c2aa9faf59a55c622760a25cbefbe941"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "3.31.0"
 
+[[CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+
 [[Crayons]]
 git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
 uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
@@ -154,6 +158,12 @@ uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "a32185f5428d3986f47c2ab78b1f216d5e6cc96f"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.5"
 
 [[Downloads]]
 deps = ["ArgTools", "LibCURL", "NetworkOptions"]
@@ -308,6 +318,18 @@ git-tree-sha1 = "5d494bc6e85c4c9b626ee0cab05daa4085486ab1"
 uuid = "5ced341a-0733-55b8-9ab6-a4889d929147"
 version = "1.9.3+0"
 
+[[MPI]]
+deps = ["Distributed", "DocStringExtensions", "Libdl", "MPICH_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "Pkg", "Random", "Requires", "Serialization", "Sockets"]
+git-tree-sha1 = "e4549a5ced642a73bd8ba2dd1d3b1d30b3530d94"
+uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+version = "0.19.0"
+
+[[MPICH_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "c6cafe3f9747c0a0740611e2dffc4d37248fb691"
+uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
+version = "3.4.2+0"
+
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
@@ -321,6 +343,12 @@ version = "1.0.3"
 [[MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[MicrosoftMPI_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "e5c90234b3967684c9c6f87b4a54549b4ce21836"
+uuid = "9237b28f-5490-5468-be7b-bb81f5f5e6cf"
+version = "10.1.3+0"
 
 [[Missings]]
 deps = ["DataAPI"]
@@ -342,6 +370,12 @@ uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[OpenMPI_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "a784e5133fc7e204c900f2cf38ed37a92ff9248d"
+uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
+version = "4.1.1+2"
 
 [[OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]

--- a/BanyanArrays/Project.toml
+++ b/BanyanArrays/Project.toml
@@ -15,9 +15,12 @@ AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
 Banyan = "706d138b-e922-45b9-a636-baf8ae0d5317"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReTest = "e0db7c4e-2690-44b9-bad6-7687da720f89"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Banyan", "Test", "ReTest", "Dates", "Distributions", "HDF5", "AWSS3"]
+test = ["AWSS3", "Banyan", "Dates", "Distributions", "FilePathsBase", "HDF5", "Statistics", "Test", "ReTest", "Random"]

--- a/BanyanArrays/src/array.jl
+++ b/BanyanArrays/src/array.jl
@@ -167,7 +167,7 @@ function read_hdf5(path; kwargs...)
     Array{A_loc.eltype,A_loc.ndims}(A, Future(A_loc.size))
 end
 
-function write_hdf5(A, path; kwargs...)
+function write_hdf5(A, path; invalidate_location=true, invalidate_sample=true, kwargs...)
     # # A_loc = Remote(pathname, mount)
     # destined(A, Remote(path, delete_from_cache=true))
     # mutated(A)
@@ -189,7 +189,7 @@ function write_hdf5(A, path; kwargs...)
     pt(A, Blocked(A) | Replicated())
     partitioned_computation(
         A,
-        destination=Remote(path; merge(Dict(:invalidate_location=>true, :invalidate_sample=>true), kwargs)...),
+        destination=Remote(path; invalidate_location=invalidate_location, invalidate_sample=invalidate_sample, kwargs...),
         new_source=_->Remote(path)
     )
 end

--- a/BanyanArrays/test/Project.toml
+++ b/BanyanArrays/test/Project.toml
@@ -2,6 +2,7 @@
 Banyan = "706d138b-e922-45b9-a636-baf8ae0d5317"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"

--- a/BanyanArrays/test/runtests.jl
+++ b/BanyanArrays/test/runtests.jl
@@ -6,13 +6,16 @@ global jobs_for_testing = Dict()
 
 function destroy_all_jobs_for_testing()
     global jobs_for_testing
-    for job_id in values(jobs_for_testing)
+    for (job_config_hash, job_id) in jobs_for_testing
         destroy_job(job_id)
+        delete!(jobs_for_testing, job_config_hash)
     end
 end
 
 function use_job_for_testing(f::Function;
     sample_rate = 2,
+    max_exact_sample_length = 50,
+    with_s3fs = nothing,
     scheduling_config_name = "default scheduling",
 )
     haskey(ENV, "BANYAN_CLUSTER_NAME") || error(
@@ -20,7 +23,9 @@ function use_job_for_testing(f::Function;
     )
 
     # This will be a more complex hash if there are more possible ways of
-    # configuring a job for testing
+    # configuring a job for testing. Different sample rates are typically used
+    # to test different data sizes. Stress tests may need a much greater sample
+    # rate.
     job_config_hash = sample_rate
 
     # Set the job and create a new one if needed
@@ -32,7 +37,7 @@ function use_job_for_testing(f::Function;
             create_job(
                 cluster_name = ENV["BANYAN_CLUSTER_NAME"],
                 nworkers = 2,
-                banyanfile_path = "file://res/BanyanfileDebug.json",
+                banyanfile_path = "file://res/Banyanfile.json",
                 sample_rate = sample_rate,
                 return_logs = true,
             )
@@ -40,7 +45,15 @@ function use_job_for_testing(f::Function;
     )
 
     # If selected job has already failed, this will throw an error.
-    get_job()
+    jobs_for_testing[job_config_hash] = get_job_id()
+
+    # Set the maximum exact sample length
+    ENV["BANYAN_MAX_EXACT_SAMPLE_LENGTH"] = string(max_exact_sample_length)
+
+    # Force usage of S3FS if so desired
+    if !isnothing(with_s3fs)
+        ENV["BANYAN_USE_S3FS"] = with_s3fs ? "1" : "0"
+    end
 
     configure_scheduling(name = scheduling_config_name)
 
@@ -55,6 +68,7 @@ function use_job_for_testing(f::Function;
         # destroyed or failed.
         destroy_all_jobs_for_testing()
         rethrow()
+        # If no errors occur, we will destroy all jobs in the `finally...` block.
     end
 end
 

--- a/BanyanArrays/test/runtests.jl
+++ b/BanyanArrays/test/runtests.jl
@@ -12,7 +12,8 @@ function destroy_all_jobs_for_testing()
     end
 end
 
-function use_job_for_testing(f::Function;
+function use_job_for_testing(
+    f::Function;
     sample_rate = 2,
     max_exact_sample_length = 50,
     with_s3fs = nothing,
@@ -74,7 +75,7 @@ end
 
 global data_for_testing = false
 
-function use_data(data_src="S3")
+function use_data(data_src = "S3")
     global data_for_testing
 
     if !data_for_testing && data_src == "S3"

--- a/BanyanDataFrames/src/df.jl
+++ b/BanyanDataFrames/src/df.jl
@@ -60,7 +60,7 @@ read_arrow(p; kwargs...) = read_csv(p; kwargs...)
 
 # TODO: For writing functions, if a file is specified, enforce Replicated
 
-function write_csv(df, path; kwargs...)
+function write_csv(df, path; invalidate_location=true, invalidate_sample=true, kwargs...)
     # destined(df, Remote(path, delete_from_cache=true))
     # mutated(df)
     # partitioned_with() do
@@ -75,7 +75,7 @@ function write_csv(df, path; kwargs...)
     end
     partitioned_computation(
         df,
-        destination=Remote(path; merge(Dict(:invalidate_location=>true, :invalidate_sample=>true), kwargs)...),
+        destination=Remote(path; invalidate_location=invalidate_location, invalidate_sample=invalidate_sample, kwargs...),
         new_source=_->Remote(path)
     )
 end

--- a/BanyanDataFrames/test/runtests.jl
+++ b/BanyanDataFrames/test/runtests.jl
@@ -6,13 +6,16 @@ global jobs_for_testing = Dict()
 
 function destroy_all_jobs_for_testing()
     global jobs_for_testing
-    for job_id in values(jobs_for_testing)
+    for (job_config_hash, job_id) in jobs_for_testing
         destroy_job(job_id)
+        delete!(jobs_for_testing, job_config_hash)
     end
 end
 
 function use_job_for_testing(f::Function;
     sample_rate = 2,
+    max_exact_sample_length = 50,
+    with_s3fs = nothing,
     scheduling_config_name = "default scheduling",
 )
     haskey(ENV, "BANYAN_CLUSTER_NAME") || error(
@@ -20,7 +23,9 @@ function use_job_for_testing(f::Function;
     )
 
     # This will be a more complex hash if there are more possible ways of
-    # configuring a job for testing
+    # configuring a job for testing. Different sample rates are typically used
+    # to test different data sizes. Stress tests may need a much greater sample
+    # rate.
     job_config_hash = sample_rate
 
     # Set the job and create a new one if needed
@@ -32,7 +37,7 @@ function use_job_for_testing(f::Function;
             create_job(
                 cluster_name = ENV["BANYAN_CLUSTER_NAME"],
                 nworkers = 2,
-                banyanfile_path = "file://res/BanyanfileDebug.json",
+                banyanfile_path = "file://res/Banyanfile.json",
                 sample_rate = sample_rate,
                 return_logs = true,
             )
@@ -40,7 +45,15 @@ function use_job_for_testing(f::Function;
     )
 
     # If selected job has already failed, this will throw an error.
-    get_job()
+    jobs_for_testing[job_config_hash] = get_job_id()
+
+    # Set the maximum exact sample length
+    ENV["BANYAN_MAX_EXACT_SAMPLE_LENGTH"] = string(max_exact_sample_length)
+
+    # Force usage of S3FS if so desired
+    if !isnothing(with_s3fs)
+        ENV["BANYAN_USE_S3FS"] = with_s3fs ? "1" : "0"
+    end
 
     configure_scheduling(name = scheduling_config_name)
 
@@ -55,6 +68,7 @@ function use_job_for_testing(f::Function;
         # destroyed or failed.
         destroy_all_jobs_for_testing()
         rethrow()
+        # If no errors occur, we will destroy all jobs in the `finally...` block.
     end
 end
 

--- a/BanyanDataFrames/test/runtests.jl
+++ b/BanyanDataFrames/test/runtests.jl
@@ -12,7 +12,8 @@ function destroy_all_jobs_for_testing()
     end
 end
 
-function use_job_for_testing(f::Function;
+function use_job_for_testing(
+    f::Function;
     sample_rate = 2,
     max_exact_sample_length = 50,
     with_s3fs = nothing,
@@ -103,7 +104,7 @@ function use_data(file_extension, remote_kind, single_file)
             (file_extension_is_hdf5 ? "fillval" : "iris") * ".$file_extension"
         testing_dataset_local_path =
             joinpath(homedir(), ".banyan", "testing_datasets", testing_dataset_local_name)
-            
+
         # Download if not already download
         if !isfile(testing_dataset_local_path)
             # Download to local ~/.banyan/testing_datasets

--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ AWS configuration files) and the Banyan environment variables
 are saved in `banyanconfig.toml` so you don't need to specify it
 every time.
 
+For example, if you have previously specified your Banyan API key, user ID, and AWS credentials, you could:
+
+```
+cd BanyanDataFrames
+BANYAN_CLUSTER_NAME=pumpkincluster0 julia --project=. -e "using Pkg; Pkg.test(test_args=[\"ample\"])
+```
+
+If your AWS credentials are saved under a profile named `banyan-testing`, you could use `AWS_DEFAULT_PROFILE=banyan-testing`.
+
 ## Development
 
 Make sure to use the `] dev ...` command or `Pkg.dev(...)` to ensure that when you


### PR DESCRIPTION
This fixes a few issues:
- [x] Small issue in `Grouped` PT (PT = partition type) constructor
- [x] Makes job failure picked up on client side result in `destroy_job` being called
- [x] Fix issues with sample collection tests failing for HDF5

As part of this, we have now tested the functions in `utils_s3fs.jl` that allow users to still use S3 without having S3FS set up (which is hard to set up on Windows).