### PR TITLE
Use non-annotated functions in PFs and generated code

### DIFF
--- a/Banyan/src/utils_pfs.jl
+++ b/Banyan/src/utils_pfs.jl
@@ -5,8 +5,8 @@ using MPI, HDF5, DataFrames
 # Helper functions #
 ####################
 
-isa_df(obj) = (@isdefined(AbstractDataFrame)) && obj isa AbstractDataFrame
-isa_gdf(obj) = (@isdefined(GroupedDataFrame)) && obj isa GroupedDataFrame
+isa_df(obj) = (@isdefined(DataFrames.AbstractDataFrame)) && obj isa DataFrames.AbstractDataFrame
+isa_gdf(obj) = (@isdefined(DataFrames.GroupedDataFrame)) && obj isa DataFrames.GroupedDataFrame
 isa_array(obj) = obj isa AbstractArray || obj isa HDF5.Dataset
 
 get_worker_idx(comm::MPI.Comm) = MPI.Comm_rank(comm) + 1
@@ -101,7 +101,7 @@ function merge_on_executor(kind::Symbol, vbuf::MPI.VBuffer, nchunks::Integer; ke
         begin
             chunk = view(vbuf.data, (vbuf.displs[i]+1):(vbuf.displs[i]+vbuf.counts[i]))
             if kind == :df
-                DataFrame(Arrow.Table(IOBuffer(chunk)))
+                DataFrames.DataFrame(Arrow.Table(IOBuffer(chunk)))
             elseif kind == :bits
                 chunk
             else
@@ -451,7 +451,7 @@ function frombuf(kind, obj)
     elseif kind == :bits
         obj
     elseif kind == :df
-        DataFrame(Arrow.Table(obj), copycols = false)
+        DataFrames.DataFrame(Arrow.Table(obj), copycols = false)
     else
         deserialize(obj)
     end

--- a/BanyanArrays/src/array.jl
+++ b/BanyanArrays/src/array.jl
@@ -519,7 +519,7 @@ function Base.sortslices(A::Array{T,N}, dims; kwargs...) where {T,N}
     end
 
     @partitioned A dims kwargs res begin
-        res = sortslices(A, dims=dims, kwargs...)
+        res = Base.sortslices(A, dims=dims, kwargs...)
     end
 
     Array{T,N}(res, deepcopy(A.size))

--- a/BanyanDataFrames/src/df.jl
+++ b/BanyanDataFrames/src/df.jl
@@ -325,8 +325,8 @@ function DataFrames.dropmissing(df::DataFrame, args...; kwargs...)
     # partition(res_nrows, Reducing(reducer=+))
 
     @partitioned df res res_nrows args kwargs begin
-        res = dropmissing(df, args...; kwargs...)
-        res_nrows = nrow(res)
+        res = DataFrames.dropmissing(df, args...; kwargs...)
+        res_nrows = DataFrames.nrow(res)
     end
 
     res
@@ -353,9 +353,9 @@ function Base.filter(f, df::DataFrame; kwargs...)
 
     @partitioned df res res_nrows f kwargs begin
         # @show df
-        res = filter(f, df; kwargs...)
+        res = DataFrames.filter(f, df; kwargs...)
         # @show res
-        res_nrows = nrow(res)
+        res_nrows = DataFrames.nrow(res)
         # @show res_nrows
     end
 
@@ -387,7 +387,7 @@ function Missings.allowmissing(df::DataFrame)::DataFrame
         pt(df, res, Replicated())
     end
 
-    @partitioned df res begin res = allowmissing(df) end
+    @partitioned df res begin res = DataFrames.allowmissing(df) end
 
     DataFrame(res, copy(df.nrows))
 end
@@ -413,7 +413,7 @@ function Missings.disallowmissing(df::DataFrame)::DataFrame
         pt(df, res, Replicated())
     end
 
-    @partitioned df res begin res = disallowmissing(df) end
+    @partitioned df res begin res = DataFrames.disallowmissing(df) end
 
     DataFrame(res, copy(df.nrows))
 end
@@ -439,7 +439,7 @@ function Base.deepcopy(df::DataFrame)::DataFrame
         pt(df, res, Replicated())
     end
 
-    @partitioned df res begin res = deepcopy(df) end
+    @partitioned df res begin res = DataFrames.deepcopy(df) end
 
     DataFrame(res, copy(df.nrows))
 end
@@ -465,7 +465,7 @@ function Base.copy(df::DataFrame)::DataFrame
         pt(df, res, Replicated())
     end
 
-    @partitioned df res begin res = copy(df) end
+    @partitioned df res begin res = DataFrames.copy(df) end
 
     DataFrame(res, copy(df.nrows))
 
@@ -1166,7 +1166,7 @@ function DataFrames.rename(df::DataFrame, args...; kwargs...)
     end
 
     @partitioned df res args kwargs begin
-        res = rename(df, args...; kwargs...)
+        res = DataFrames.rename(df, args...; kwargs...)
     end
 
     DataFrame(res, copy(df.nrows))
@@ -1324,7 +1324,7 @@ function Base.sort(df::DataFrame, cols=:; kwargs...)
     # mutated(res)
 
     @partitioned df res cols kwargs begin
-        res = sort(df, cols; kwargs...)
+        res = DataFrames.sort(df, cols; kwargs...)
     end
 
     # statistics = sample(df, :keystatistics, by)
@@ -1417,7 +1417,7 @@ function DataFrames.innerjoin(dfs::DataFrame...; on, kwargs...)
     end
 
     @partitioned dfs on kwargs res res_nrows begin
-        res = innerjoin(dfs...; on=on, kwargs...)
+        res = DataFrames.innerjoin(dfs...; on=on, kwargs...)
         res_nrows = nrow(res)
     end
 
@@ -1493,8 +1493,8 @@ function DataFrames.unique(df::DataFrame, cols=:; kwargs...)
     end
 
     @partitioned df res res_nrows cols kwargs begin
-        res = unique(df, cols; kwargs...)
-        res_nrows = nrow(res)
+        res = DataFrames.unique(df, cols; kwargs...)
+        res_nrows = DataFrames.nrow(res)
     end
 
     res
@@ -1558,7 +1558,7 @@ function DataFrames.nonunique(df::DataFrame, cols=:; kwargs...)
     end
 
     @partitioned df df_nrows res res_size cols kwargs begin
-        res = nonunique(df, cols; kwargs...)
+        res = DataFrames.nonunique(df, cols; kwargs...)
         # @show "nonunique" res
         res_size = Tuple(df_nrows)
     end

--- a/BanyanDataFrames/src/gdf.jl
+++ b/BanyanDataFrames/src/gdf.jl
@@ -56,8 +56,8 @@ function DataFrames.groupby(df::DataFrame, cols; kwargs...)::GroupedDataFrame
     end
 
     @partitioned df gdf gdf_length cols kwargs begin
-        gdf = groupby(df, cols; kwargs...)
-        gdf_length = length(gdf)
+        gdf = DataFrames.groupby(df, cols; kwargs...)
+        gdf_length = DataFrames.length(gdf)
     end
 
     # allowedgroupingkeys = names(sample(df), compute(cols))
@@ -185,10 +185,10 @@ function DataFrames.select(gdf::GroupedDataFrame, args...; kwargs...)
     # mutated(res)
 
     @partitioned gdf gdf_parent groupcols groupkwargs args kwargs res begin
-        if !(gdf isa GroupedDataFrame) || gdf.parent != gdf_parent
-            gdf = groupby(gdf_parent, groupcols; groupkwargs...)
+        if !(gdf isa DataFrames.GroupedDataFrame) || gdf.parent != gdf_parent
+            gdf = DataFrames.groupby(gdf_parent, groupcols; groupkwargs...)
         end
-        res = select(gdf, args...; kwargs...)
+        res = DataFrames.select(gdf, args...; kwargs...)
     end
 
     DataFrame(res, copy(gdf_parent.nrows))
@@ -229,10 +229,10 @@ function DataFrames.transform(gdf::GroupedDataFrame, args...; kwargs...)
     end
 
     @partitioned gdf gdf_parent groupcols groupkwargs args kwargs res begin
-        if !(gdf isa GroupedDataFrame) || gdf.parent != gdf_parent
-            gdf = groupby(gdf_parent, groupcols; groupkwargs...)
+        if !(gdf isa DataFrames.GroupedDataFrame) || gdf.parent != gdf_parent
+            gdf = DataFrames.groupby(gdf_parent, groupcols; groupkwargs...)
         end
-        res = transform(gdf, args...; kwargs...)
+        res = DataFrames.transform(gdf, args...; kwargs...)
     end
 
     DataFrame(res, copy(gdf_parent.nrows))
@@ -278,14 +278,14 @@ function DataFrames.combine(gdf::GroupedDataFrame, args...; kwargs...)
 
     @partitioned gdf gdf_parent groupcols groupkwargs args kwargs res res_nrows begin
         println("here!")
-        if !(gdf isa GroupedDataFrame) || gdf.parent != gdf_parent
+        if !(gdf isa DataFrames.GroupedDataFrame) || gdf.parent != gdf_parent
             println("right inside here")
-            gdf = groupby(gdf_parent, groupcols; groupkwargs...)
+            gdf = DataFrames.groupby(gdf_parent, groupcols; groupkwargs...)
         end
         println("here2!")
-        res = combine(gdf, args...; kwargs...)
+        res = DataFrames.combine(gdf, args...; kwargs...)
         println("here3!")
-        res_nrows = nrow(res)
+        res_nrows = DataFrames.nrow(res)
         println("here4!")
     end
 
@@ -331,12 +331,12 @@ function DataFrames.subset(gdf::GroupedDataFrame, args...; kwargs...)
     end
 
     @partitioned gdf gdf_parent groupcols groupkwargs args kwargs res res_nrows begin
-        if !(gdf isa GroupedDataFrame) || gdf.parent != gdf_parent
-            gdf = groupby(gdf_parent, groupcols; groupkwargs...)
+        if !(gdf isa DataFrames.GroupedDataFrame) || gdf.parent != gdf_parent
+            gdf = DataFrames.groupby(gdf_parent, groupcols; groupkwargs...)
         end
-        res = subset(gdf, args...; kwargs...)
+        res = DataFrames.subset(gdf, args...; kwargs...)
         println("In subset with length(gdf)=$(length(gdf)) and nrow(gdf_parent)=$(nrow(gdf_parent)) and nrow(res)=$(nrow(res))")
-        res_nrows = nrow(res)
+        res_nrows = DataFrames.nrow(res)
     end
 
     res


### PR DESCRIPTION
This may not be comprehensive but it changes a bunch of ambiguous usage of dataframe function calls to specify that `DataFrames` should be used and _not_ `BanyanDataFrames` (that's only for testing code and end user code).