### PR TITLE
Fix sample collection for tables

### DIFF
--- a/Banyan/src/locations.jl
+++ b/Banyan/src/locations.jl
@@ -395,7 +395,11 @@ function Remote(p; shuffled=false, location_invalid = false, sample_invalid = fa
 end
 
 function get_remote_location(remotepath, remote_location=nothing, remote_sample=nothing; shuffled=false)::Location
-    @info "Collecting sample from $remotepath\n\nThis will take some time but the sample will be cached for future use. Note that writing to this location will invalidate the cached sample."
+    if isnothing(remote_sample)
+        @info "Collecting sample from $remotepath\n\nThis will take some time but the sample will be cached for future use. Note that writing to this location will invalidate the cached sample."
+    elseif isnothing(remote_location)
+        @info "Collecting location information about $remotepath. This will take some time."
+    end
 
     # If both the location and sample are already cached, just return them
     if !isnothing(remote_location) && !isnothing(remote_sample)

--- a/Banyan/src/pfs.jl
+++ b/Banyan/src/pfs.jl
@@ -137,6 +137,7 @@ function ReadBlock(
     # this value to disk
     if loc_name == "Disk"
         name = loc_params["path"]
+        # TODO: isdir might not work for S3FS
         if isdir(getpath(name))
             files = []
             nrows = 0

--- a/Banyan/src/utils_pfs.jl
+++ b/Banyan/src/utils_pfs.jl
@@ -5,8 +5,8 @@ using MPI, HDF5, DataFrames
 # Helper functions #
 ####################
 
-isa_df(obj) = (@isdefined(DataFrames.AbstractDataFrame)) && obj isa DataFrames.AbstractDataFrame
-isa_gdf(obj) = (@isdefined(DataFrames.GroupedDataFrame)) && obj isa DataFrames.GroupedDataFrame
+isa_df(obj) = (@isdefined(DataFrames) && @isdefined(AbstractDataFrame)) && obj isa DataFrames.AbstractDataFrame
+isa_gdf(obj) = (@isdefined(DataFrames) && @isdefined(GroupedDataFrame)) && obj isa DataFrames.GroupedDataFrame
 isa_array(obj) = obj isa AbstractArray || obj isa HDF5.Dataset
 
 get_worker_idx(comm::MPI.Comm) = MPI.Comm_rank(comm) + 1

--- a/Banyan/src/utils_s3fs.jl
+++ b/Banyan/src/utils_s3fs.jl
@@ -61,7 +61,13 @@ function download_remote_s3_path(path)
     # bucket = "banyan-cluster-data-myfirstcluster"
     mount = joinpath(homedir(), ".banyan", "mnt", "s3", bucket)
 
-    if (!failed_to_use_s3fs && !haskey(ENV, "BANYAN_USE_S3FS")) || ENV["BANYAN_USE_S3FS"] == "1"
+    # If specified, do not allow even attempting to use S3FS.
+    if haskey(ENV, "BANYAN_USE_S3FS") && ENV["BANYAN_USE_S3FS"] == "0"
+        failed_to_use_s3fs = true
+    end
+
+    # Don't attempt to use S3FS if we have ever failed to use S3FS.
+    if !failed_to_use_s3fs
         # Ensure path to mount exists
         no_mount = false
         try

--- a/Banyan/test/runtests.jl
+++ b/Banyan/test/runtests.jl
@@ -137,7 +137,7 @@ function use_data(file_extension, remote_kind, single_file)
         )
 
         # Create the file if not already created
-        if !ispath(testing_dataset_s3_path)
+        if single_file ? !ispath(testing_dataset_s3_path) : !ispath(joinpath(testing_dataset_s3_path, "part_0.$file_extension"),)
             # Download if not already download
             if !isfile(testing_dataset_local_path)
                 # Download to local ~/.banyan/testing_datasets
@@ -159,6 +159,7 @@ function use_data(file_extension, remote_kind, single_file)
                 cp(Path(testing_dataset_local_path), testing_dataset_s3_path)
             else
                 for i = 0:9
+
                     cp(
                         Path(testing_dataset_local_path),
                         joinpath(testing_dataset_s3_path, "part_$i.$file_extension"),

--- a/Banyan/test/sample_collection.jl
+++ b/Banyan/test/sample_collection.jl
@@ -44,8 +44,8 @@
         end
         remote_location = Remote(
             src_name,
-            location_invalid = (reusing == "nothing" || reusing == "location"),
-            sample_invalid = (reusing == "nothing" || reusing == "sample"),
+            location_invalid = (reusing == "nothing" || reusing == "sample"),
+            sample_invalid = (reusing == "nothing" || reusing == "location"),
             shuffled = with_or_without_shuffled == "with",
         )
 
@@ -75,7 +75,7 @@
         # Verify the sample
         sample_nrows =
             contains(src_name, "h5") ? size(remote_location.sample.value, 1) :
-            nrows(remote_location.sample.value)
+            nrow(remote_location.sample.value)
         if exact_or_inexact == "Exact"
             @test sample_nrows == src_nrows
         else

--- a/Banyan/test/sample_collection.jl
+++ b/Banyan/test/sample_collection.jl
@@ -6,12 +6,7 @@
 # - Test shuffled, similar files, default, invalidated location but reused sample or reused location
 # - Verify no error, length of returned sample, location files and their nrows,
 # (eventually) ensure that rows come from the right files
-@testset "$exact_or_inexact sample collected from $(titlecase(file_extension)) $(single_file ? "file" : "directory") on $on $with_or_without_s3fs S3FS with $optimization reusing $reusing" for exact_or_inexact in
-<<<<<<< HEAD
-                                                                                                                                                                                                [
-=======
-                                                                                                                                       [
->>>>>>> Got all HDF5 sample collection tests to pass
+@testset "$exact_or_inexact sample collected from $(titlecase(file_extension)) $(single_file ? "file" : "directory") on $on $with_or_without_s3fs S3FS with $optimization reusing $reusing" for exact_or_inexact in [
         "Exact",
         "Inexact",
     ],
@@ -79,7 +74,8 @@
 
         # Verify the sample
         sample_nrows =
-            contains(src_name, "h5") ? size(remote_location.sample.value, 1) : nrows(remote_location.sample.value)
+            contains(src_name, "h5") ? size(remote_location.sample.value, 1) :
+            nrows(remote_location.sample.value)
         if exact_or_inexact == "Exact"
             @test sample_nrows == src_nrows
         else

--- a/Banyan/test/sample_collection.jl
+++ b/Banyan/test/sample_collection.jl
@@ -7,7 +7,11 @@
 # - Verify no error, length of returned sample, location files and their nrows,
 # (eventually) ensure that rows come from the right files
 @testset "$exact_or_inexact sample collected from $(titlecase(file_extension)) $(single_file ? "file" : "directory") on $on $with_or_without_s3fs S3FS with $optimization reusing $reusing" for exact_or_inexact in
+<<<<<<< HEAD
                                                                                                                                                                                                 [
+=======
+                                                                                                                                       [
+>>>>>>> Got all HDF5 sample collection tests to pass
         "Exact",
         "Inexact",
     ],
@@ -75,8 +79,7 @@
 
         # Verify the sample
         sample_nrows =
-            contains(src_name, "h5") ? size(remote_location.sample.value, 1) :
-            nrows(remote_location.sample.value)
+            contains(src_name, "h5") ? size(remote_location.sample.value, 1) : nrows(remote_location.sample.value)
         if exact_or_inexact == "Exact"
             @test sample_nrows == src_nrows
         else

--- a/Banyan/test/sample_collection.jl
+++ b/Banyan/test/sample_collection.jl
@@ -6,7 +6,8 @@
 # - Test shuffled, similar files, default, invalidated location but reused sample or reused location
 # - Verify no error, length of returned sample, location files and their nrows,
 # (eventually) ensure that rows come from the right files
-@testset "$exact_or_inexact sample collected from $(titlecase(file_extension)) $(single_file ? "file" : "directory") on $on $with_or_without_s3fs S3FS with $optimization reusing $reusing" for exact_or_inexact in [
+@testset "$exact_or_inexact sample collected from $file_extension $(single_file ? "file" : "directory") on $on $with_or_without_s3fs S3FS $with_or_without_shuffled shuffled reusing $reusing" for exact_or_inexact in
+                                                                                                                                                                                                [
         "Exact",
         "Inexact",
     ],
@@ -23,7 +24,7 @@
         ("parquet", false, "S3", 150 * 10),
         ("arrow", false, "S3", 150 * 10),
     ],
-    optimization in ["shuffled", "similar files"],
+    with_or_without_shuffled in ["with", "without"],
     reusing in ["nothing", "sample", "location", "sample and location"],
     with_or_without_s3fs in ["with", "without"]
 
@@ -45,8 +46,7 @@
             src_name,
             location_invalid = (reusing == "nothing" || reusing == "location"),
             sample_invalid = (reusing == "nothing" || reusing == "sample"),
-            shuffled = optimization == "shuffled",
-            similar_files = optimization == "similar files",
+            shuffled = with_or_without_shuffled == "with",
         )
 
         # Verify the location


### PR DESCRIPTION
This PR gets sample collection working for remote locations (S3 or Internet) storing single-file or multi-file datasets in HDF5, CSV, Parquet, or Arrow format.

# No S3FS!

Samples can be collected either with or without S3FS (with S3FS might be faster since it reads into memory).

# Optimizations
There is also an optimized case (`shuffled=true`) for when your data is already shuffled or files are similar enough that we only need to read in some files to build up a sample. Also, samples and location info (info about what files there are and how many rows each file has) can be reused (`invalidate_sample=false`, `invalidate_location=false`) for faster sample collection instead of them just being completely invalidated after writing (we cache samples but typically have to invalidate after a write ; currently the cache is local on the client side but in the future the cache will be in S3).