### PR TITLE
Fix issues in configure()

### DIFF
--- a/Banyan/src/utils.jl
+++ b/Banyan/src/utils.jl
@@ -142,7 +142,6 @@ function configure(; kwargs...)
 
     # Load arguments
     kwargs = Dict(kwargs)
-    # username = if_in_or(:username, kwargs)
     user_id = if_in_or(:user_id, kwargs)
     api_key = if_in_or(:api_key, kwargs)
     ec2_key_pair_name = if_in_or(:ec2_key_pair_name, kwargs)
@@ -156,9 +155,6 @@ function configure(; kwargs...)
     if isnothing(api_key) && haskey(ENV, "BANYAN_API_KEY")
         api_key = ENV["BANYAN_API_KEY"]
     end
-    # if isnothing(username) && haskey(ENV, "BANYAN_USERNAME")
-    #     api_key = ENV["BANYAN_USERNAME"]
-    # end
 
     # Check banyanconfig file
     if isnothing(user_id) && haskey(banyan_config, "banyan") && haskey(banyan_config["banyan"], "user_id")
@@ -167,9 +163,6 @@ function configure(; kwargs...)
     if isnothing(api_key) && haskey(banyan_config, "banyan") && haskey(banyan_config["banyan"], "api_key")
         api_key = banyan_config["banyan"]["api_key"]
     end
-    # if isnothing(username) && haskey(banyan_config, "banyan") && haskey(banyan_config["banyan"], "username")
-    #     username = banyan_config["banyan"]["username"]
-    # end
 
     # Initialize
     is_modified = false
@@ -177,25 +170,20 @@ function configure(; kwargs...)
 
     # Ensure a configuration has been created or can be created. Otherwise,
     # return nothing
-    if isnothing(banyan_config)
-        if !isnothing(user_id) && !isnothing(api_key) && !isnothing(username)
+    if isnothing(banyan_config) || isempty(banyan_config)
+        if !isnothing(user_id) && !isnothing(api_key)
             banyan_config = Dict(
                 "banyan" =>
-                    Dict("username" => username, "user_id" => user_id, "api_key" => api_key),
+                    Dict("user_id" => user_id, "api_key" => api_key),
                 "aws" => Dict(),
             )
             is_modified = true
         else
-            error("Your username, user ID, and API key must be specified using either keyword arguments, environment variables, or banyanconfig.toml")
+            error("Your user ID and API key must be specified using either keyword arguments, environment variables, or banyanconfig.toml")
         end
     end
 
     # Check for changes in required
-    # if !isnothing(username) &&
-    #    (username != banyan_config["banyan"]["username"])
-    #     banyan_config["banyan"]["username"] = username
-    #     is_modified = true
-    # end
     if !isnothing(user_id) &&
         (user_id != banyan_config["banyan"]["user_id"])
          banyan_config["banyan"]["user_id"] = user_id
@@ -205,10 +193,6 @@ function configure(; kwargs...)
         banyan_config["banyan"]["api_key"] = api_key
         is_modified = true
     end
-    # if !isnothing(username) && (username != banyan_config["banyan"]["username"])
-    #     banyan_config["banyan"]["username"] = username
-    #     is_modified = true
-    # end
 
     # Check for changes in potentially required
 


### PR DESCRIPTION
Fix issues in not requiring banyanconfig file to contain `username` and errors when file is being created for the first time.