### PR TITLE
Make orderinghash accept any string

### DIFF
--- a/Banyan/src/Banyan.jl
+++ b/Banyan/src/Banyan.jl
@@ -92,7 +92,8 @@ export partitioned_using,
     keep_all_sample_keys_renamed,
     keep_sample_keys_named,
     keep_sample_keys,
-    keep_sample_rate
+    keep_sample_rate,
+    partitioned_using_modules
 
 # Debugging
 export is_debug_on,

--- a/Banyan/src/annotation.jl
+++ b/Banyan/src/annotation.jl
@@ -327,6 +327,11 @@ end
 
 invert(mutation::Dict{Future,Future}) = Dict(new => old for (old, new) in mutation)
 
+function partitioned_using_modules(m...)
+    global curr_delayed_task
+    union!(curr_delayed_task.used_modules, m)
+end
+
 macro partitioned(ex...)
     res = quote end
 

--- a/Banyan/src/annotation.jl
+++ b/Banyan/src/annotation.jl
@@ -705,6 +705,10 @@ duplicated_constraints_for_batching(pc::PartitioningConstraints, pa::PartitionAn
                         PartitioningConstraintOverGroup(c.type, duplicate_args(c.args, pa)),
                     ]
                 elseif c.type == "CROSS" || startswith(c.type, "AT_MOST=")
+                    # Note that with Cross constraints, the order of the
+                    # arguments matters. But actually that doesnt matter.
+                    # The scheduler will automaticcally ensure that the order
+                    # of PTs in a PT stack is obeyed.
                     # ||
                     # c.type == "MATCH" || startswith(c.type, "MATCH_ON")
                     [

--- a/Banyan/src/future.jl
+++ b/Banyan/src/future.jl
@@ -12,7 +12,9 @@ mutable struct Future <: AbstractFuture
             try
                 record_request(DestroyRequest(fut.value_id))
             catch e
-                @warn "Failed to destroy value $(fut.value_id) because job has stopped: $e"
+                # `record_request` will fail if there isn't any job to add the
+                # request to. So we just continue silently.
+                # @warn "Failed to destroy value $(fut.value_id) because job has stopped: $e"
             end
         end
 

--- a/Banyan/src/requests.jl
+++ b/Banyan/src/requests.jl
@@ -354,6 +354,9 @@ function send_evaluation(value_id::ValueId, job_id::JobId)
 
     @debug "Sending evaluation request"
 
+    # Get list of the modules used in the code regions here
+    used_modules = union(vcat([req.task.used_modules for req in get_job().pending_requests if req isa RecordTaskRequest]...))
+
     # Submit evaluation request
     println("Submitting evaluation request")
     @show value_id

--- a/Banyan/src/requests.jl
+++ b/Banyan/src/requests.jl
@@ -355,7 +355,7 @@ function send_evaluation(value_id::ValueId, job_id::JobId)
     @debug "Sending evaluation request"
 
     # Get list of the modules used in the code regions here
-    used_packages = union(vcat([str(req.task.used_modules) for req in get_job().pending_requests if req isa RecordTaskRequest]...))
+    used_packages = union(vcat([req.task.used_modules for req in get_job().pending_requests if req isa RecordTaskRequest]...))
     println("HERE IS A MODULE: ", used_packages)
 
     # Submit evaluation request

--- a/Banyan/src/requests.jl
+++ b/Banyan/src/requests.jl
@@ -348,7 +348,7 @@ function configure_scheduling(;kwargs...)
     end
 end
 
-function send_evaluation(value_id::ValueId, job_id::JobId)
+function send_evaluation(value_id::ValueId, job_id::JobId, module_packages)
     global encourage_parallelism
     global encourage_parallelism_with_batches
 
@@ -373,7 +373,8 @@ function send_evaluation(value_id::ValueId, job_id::JobId)
                 "encourage_parallelism_with_batches" => encourage_parallelism_with_batches
             ),
             "num_bang_values_issued" => get_num_bang_values_issued(),
-            "packages" => get_loaded_packages()
+            "main_packages" => get_loaded_packages(),
+            "module_packages" => module_packages,
         ),
     )
 

--- a/Banyan/src/requests.jl
+++ b/Banyan/src/requests.jl
@@ -348,14 +348,15 @@ function configure_scheduling(;kwargs...)
     end
 end
 
-function send_evaluation(value_id::ValueId, job_id::JobId, module_packages)
+function send_evaluation(value_id::ValueId, job_id::JobId)
     global encourage_parallelism
     global encourage_parallelism_with_batches
 
     @debug "Sending evaluation request"
 
     # Get list of the modules used in the code regions here
-    used_modules = union(vcat([req.task.used_modules for req in get_job().pending_requests if req isa RecordTaskRequest]...))
+    used_packages = union(vcat([str(req.task.used_modules) for req in get_job().pending_requests if req isa RecordTaskRequest]...))
+    println("HERE IS A MODULE: ", used_packages)
 
     # Submit evaluation request
     println("Submitting evaluation request")
@@ -374,7 +375,7 @@ function send_evaluation(value_id::ValueId, job_id::JobId, module_packages)
             ),
             "num_bang_values_issued" => get_num_bang_values_issued(),
             "main_packages" => get_loaded_packages(),
-            "module_packages" => module_packages,
+            "used_packages" => used_packages,
         ),
     )
 

--- a/Banyan/src/tasks.jl
+++ b/Banyan/src/tasks.jl
@@ -4,6 +4,7 @@
 
 mutable struct DelayedTask
     # Fields for use in processed task ready to be recorded
+    used_modules::Vector
     code::String
     value_names::Vector{Tuple{ValueId,String}}
     effects::Dict{ValueId,String}
@@ -14,7 +15,7 @@ mutable struct DelayedTask
     mutation::Dict{Future,Future} # This gets converted to `effects`
 end
 
-DelayedTask() = DelayedTask("", [], Dict(), [PartitionAnnotation()], nothing, nothing, Dict())
+DelayedTask() = DelayedTask([], "", [], Dict(), [PartitionAnnotation()], nothing, nothing, Dict())
 
 function to_jl(task::DelayedTask)
     return Dict(

--- a/Banyan/src/utils_pfs.jl
+++ b/Banyan/src/utils_pfs.jl
@@ -182,7 +182,7 @@ end
 # equally-sized numbers
 # NOTE: This is an "order-preserving hash function" (google that for more info)
 orderinghash(x::Any) = x # This lets us handle numbers and dates
-orderinghash(s::String) = Integer.(codeunits(first(s, 32) * repeat(" ", 32-length(s))))
+orderinghash(s::AbstractString) = Integer.(codeunits(first(s, 32) * repeat(" ", 32-length(s))))
 orderinghash(A::AbstractArray) = orderinghash(first(A))
 
 to_vector(v::Vector) = v

--- a/BanyanDataFrames/src/df.jl
+++ b/BanyanDataFrames/src/df.jl
@@ -309,6 +309,7 @@ function DataFrames.dropmissing(df::DataFrame, args...; kwargs...)
     #     end
     # end
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         # We need to maintain these sample properties and hold constraints on
         # memory usage so that we can properly handle data skew
@@ -341,6 +342,7 @@ function Base.filter(f, df::DataFrame; kwargs...)
     res = DataFrame(Future(), res_nrows)
     kwargs = Future(kwargs)
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_all_sample_keys(res, df, drifted=true)
         keep_sample_rate(res, df)
@@ -370,6 +372,7 @@ end
 function Missings.allowmissing(df::DataFrame)::DataFrame
     res = Future()
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_all_sample_keys(res, df)
         keep_sample_rate(res, df)
@@ -396,6 +399,7 @@ end
 function Missings.disallowmissing(df::DataFrame)::DataFrame
     res = Future()
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_all_sample_keys(res, df)
         keep_sample_rate(res, df)
@@ -422,6 +426,7 @@ end
 function Base.deepcopy(df::DataFrame)::DataFrame
     res = Future()
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_all_sample_keys(res, df)
         keep_sample_rate(res, df)
@@ -448,6 +453,7 @@ end
 function Base.copy(df::DataFrame)::DataFrame
     res = Future()
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_all_sample_keys(res, df)
         keep_sample_rate(res, df)
@@ -641,6 +647,7 @@ function Base.getindex(df::DataFrame, rows=:, cols=:)
             DataFrame(Future(), res_size)
         end
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_all_sample_keys(res, df, drifted=filter_rows)
         keep_sample_rate(res, df)
@@ -976,6 +983,7 @@ function Base.setindex!(df::DataFrame, v::Union{BanyanArrays.Vector, BanyanArray
     # cols = Future(Symbol.(names(sample(df), cols)))
     cols = Future(cols)
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_all_sample_keys(res, df)
         keep_sample_rate(res, df)
@@ -1145,6 +1153,7 @@ function DataFrames.rename(df::DataFrame, args...; kwargs...)
     args = Future(args)
     kwargs = Future(kwargs)
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_all_sample_keys_renamed(res, df)
         keep_sample_rate(res, df)
@@ -1309,6 +1318,7 @@ function Base.sort(df::DataFrame, cols=:; kwargs...)
 
     # TODO: Change to_vector(x) to [x;]
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_sample_keys(sortingkey, res, df)
         keep_sample_rate(res, df)
@@ -1354,6 +1364,7 @@ function DataFrames.innerjoin(dfs::DataFrame...; on, kwargs...)
     on = Future(on)
     kwargs = Future(kwargs)
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         # NOTE: `to_vector` is necessary here (`[on...]` won't cut it) because
         # we allow for a vector of pairs
@@ -1483,6 +1494,7 @@ function DataFrames.unique(df::DataFrame, cols=:; kwargs...)
     cols = Future(cols)
     kwargs = Future(kwargs)
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_sample_keys(columns, res, df, drifted=true)
         keep_sample_rate(res, df)
@@ -1547,6 +1559,7 @@ function DataFrames.nonunique(df::DataFrame, cols=:; kwargs...)
     cols = Future(cols)
     kwargs = Future(kwargs)
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_sample_rate(res, df)
     end

--- a/BanyanDataFrames/src/df.jl
+++ b/BanyanDataFrames/src/df.jl
@@ -309,7 +309,7 @@ function DataFrames.dropmissing(df::DataFrame, args...; kwargs...)
     #     end
     # end
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         # We need to maintain these sample properties and hold constraints on
         # memory usage so that we can properly handle data skew
@@ -342,7 +342,7 @@ function Base.filter(f, df::DataFrame; kwargs...)
     res = DataFrame(Future(), res_nrows)
     kwargs = Future(kwargs)
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_all_sample_keys(res, df, drifted=true)
         keep_sample_rate(res, df)
@@ -372,7 +372,7 @@ end
 function Missings.allowmissing(df::DataFrame)::DataFrame
     res = Future()
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_all_sample_keys(res, df)
         keep_sample_rate(res, df)
@@ -399,7 +399,7 @@ end
 function Missings.disallowmissing(df::DataFrame)::DataFrame
     res = Future()
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_all_sample_keys(res, df)
         keep_sample_rate(res, df)
@@ -426,7 +426,7 @@ end
 function Base.deepcopy(df::DataFrame)::DataFrame
     res = Future()
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_all_sample_keys(res, df)
         keep_sample_rate(res, df)
@@ -453,7 +453,7 @@ end
 function Base.copy(df::DataFrame)::DataFrame
     res = Future()
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_all_sample_keys(res, df)
         keep_sample_rate(res, df)
@@ -647,7 +647,7 @@ function Base.getindex(df::DataFrame, rows=:, cols=:)
             DataFrame(Future(), res_size)
         end
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_all_sample_keys(res, df, drifted=filter_rows)
         keep_sample_rate(res, df)
@@ -983,7 +983,7 @@ function Base.setindex!(df::DataFrame, v::Union{BanyanArrays.Vector, BanyanArray
     # cols = Future(Symbol.(names(sample(df), cols)))
     cols = Future(cols)
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_all_sample_keys(res, df)
         keep_sample_rate(res, df)
@@ -1153,7 +1153,7 @@ function DataFrames.rename(df::DataFrame, args...; kwargs...)
     args = Future(args)
     kwargs = Future(kwargs)
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_all_sample_keys_renamed(res, df)
         keep_sample_rate(res, df)
@@ -1318,7 +1318,7 @@ function Base.sort(df::DataFrame, cols=:; kwargs...)
 
     # TODO: Change to_vector(x) to [x;]
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_sample_keys(sortingkey, res, df)
         keep_sample_rate(res, df)
@@ -1364,7 +1364,7 @@ function DataFrames.innerjoin(dfs::DataFrame...; on, kwargs...)
     on = Future(on)
     kwargs = Future(kwargs)
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         # NOTE: `to_vector` is necessary here (`[on...]` won't cut it) because
         # we allow for a vector of pairs
@@ -1494,7 +1494,7 @@ function DataFrames.unique(df::DataFrame, cols=:; kwargs...)
     cols = Future(cols)
     kwargs = Future(kwargs)
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_sample_keys(columns, res, df, drifted=true)
         keep_sample_rate(res, df)
@@ -1559,7 +1559,7 @@ function DataFrames.nonunique(df::DataFrame, cols=:; kwargs...)
     cols = Future(cols)
     kwargs = Future(kwargs)
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_sample_rate(res, df)
     end

--- a/BanyanDataFrames/src/gdf.jl
+++ b/BanyanDataFrames/src/gdf.jl
@@ -40,7 +40,7 @@ function DataFrames.groupby(df::DataFrame, cols; kwargs...)::GroupedDataFrame
 
     groupingkeys = names(sample(df), collect(cols))
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_sample_rate(gdf, df)
     end
@@ -127,7 +127,7 @@ function DataFrames.select(gdf::GroupedDataFrame, args...; kwargs...)
 
     groupingkeys = names(sample(gdf_parent), collect(groupcols))
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_sample_keys(if get(collect(kwargs), :keepkeys, true) groupingkeys else [] end, res, gdf_parent, drifted=true)
         keep_sample_rate(res, gdf_parent)
@@ -211,7 +211,7 @@ function DataFrames.transform(gdf::GroupedDataFrame, args...; kwargs...)
     # TODO: Put groupingkeys in GroupedDataFrame
     groupingkeys = names(sample(gdf_parent), collect(groupcols))
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_sample_keys(
             get(collect(kwargs), :keepkeys, true) ? groupingkeys : [], res, gdf_parent,
@@ -260,7 +260,7 @@ function DataFrames.combine(gdf::GroupedDataFrame, args...; kwargs...)
     @show sample(gdf_parent)
     @show groupingkeys
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_sample_keys(
             get(collect(kwargs), :keepkeys, true) ? groupingkeys : [], res, gdf_parent,
@@ -319,7 +319,7 @@ function DataFrames.subset(gdf::GroupedDataFrame, args...; kwargs...)
     # TODO: Put groupingkeys in GroupedDataFrame
     groupingkeys = names(sample(gdf_parent), collect(groupcols))
 
-    partitioned_using_modules(DataFrames)
+    partitioned_using_modules("DataFrames")
     partitioned_using() do
         keep_sample_keys(
             get(collect(kwargs), :keepkeys, true) ? groupingkeys : [], res, gdf_parent,

--- a/BanyanDataFrames/src/gdf.jl
+++ b/BanyanDataFrames/src/gdf.jl
@@ -40,6 +40,7 @@ function DataFrames.groupby(df::DataFrame, cols; kwargs...)::GroupedDataFrame
 
     groupingkeys = names(sample(df), collect(cols))
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_sample_rate(gdf, df)
     end
@@ -126,6 +127,7 @@ function DataFrames.select(gdf::GroupedDataFrame, args...; kwargs...)
 
     groupingkeys = names(sample(gdf_parent), collect(groupcols))
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_sample_keys(if get(collect(kwargs), :keepkeys, true) groupingkeys else [] end, res, gdf_parent, drifted=true)
         keep_sample_rate(res, gdf_parent)
@@ -209,6 +211,7 @@ function DataFrames.transform(gdf::GroupedDataFrame, args...; kwargs...)
     # TODO: Put groupingkeys in GroupedDataFrame
     groupingkeys = names(sample(gdf_parent), collect(groupcols))
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_sample_keys(
             get(collect(kwargs), :keepkeys, true) ? groupingkeys : [], res, gdf_parent,
@@ -257,6 +260,7 @@ function DataFrames.combine(gdf::GroupedDataFrame, args...; kwargs...)
     @show sample(gdf_parent)
     @show groupingkeys
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_sample_keys(
             get(collect(kwargs), :keepkeys, true) ? groupingkeys : [], res, gdf_parent,
@@ -315,6 +319,7 @@ function DataFrames.subset(gdf::GroupedDataFrame, args...; kwargs...)
     # TODO: Put groupingkeys in GroupedDataFrame
     groupingkeys = names(sample(gdf_parent), collect(groupcols))
 
+    partitioned_using_modules(DataFrames)
     partitioned_using() do
         keep_sample_keys(
             get(collect(kwargs), :keepkeys, true) ? groupingkeys : [], res, gdf_parent,


### PR DESCRIPTION
`orderinghash` is an order-preserving hash function. This PR modifies it to accept any string including `InlineString`s, thus resolving an issue @cailinw ran into with sampled divisions being weird.

This also adds `partitioned_using_modules` and uses it in BanyanDataFrames.jl.