### PR TITLE
Add tests for empty DataFrames

### DIFF
--- a/BanyanDataFrames/test/groupby_filter_indexing.jl
+++ b/BanyanDataFrames/test/groupby_filter_indexing.jl
@@ -548,7 +548,9 @@ end
         if filetype == "directory":
             # Create empty directory
             path = "s3://$(bucket)/empty_dir"
-            mkpath(S3Path(path))
+            if !ispath(S3Path(path))
+                mkpath(S3Path(path))
+            end
             headertype = "no header"
         else
             if headertype == "header":
@@ -564,7 +566,7 @@ end
             df = read_file(path)
 
             if headertype == "header"
-                @test size(df2) == (0, 2)
+                @test size(df) == (0, 2)
             elseif headertype == "no header":
                 @test size(df) == (0, 0)
             end

--- a/BanyanDataFrames/test/runtests.jl
+++ b/BanyanDataFrames/test/runtests.jl
@@ -216,6 +216,12 @@ function use_stress_data()
     setup_stress_tests()
 end
 
+function use_empty_data()
+    cleanup_tests()
+    setup_basic_tests()
+    setup_empty_tests()
+end
+
 include("sample_computation.jl")
 include("groupby_filter_indexing.jl")
 

--- a/BanyanDataFrames/test/utils_data.jl
+++ b/BanyanDataFrames/test/utils_data.jl
@@ -139,7 +139,9 @@ function setup_basic_tests(bucket_name=get_cluster_s3_bucket_name())
             "iris_species_info.arrow",
         )
     end
+end
 
+function setup_empty_tests(bucket_name=get_cluster_s3_bucket_name())
     # Write empty dataframe
     empty_df = DataFrames.DataFrame()
     write_df_to_csv_to_s3(

--- a/BanyanDataFrames/test/utils_data.jl
+++ b/BanyanDataFrames/test/utils_data.jl
@@ -144,37 +144,45 @@ end
 function setup_empty_tests(bucket_name=get_cluster_s3_bucket_name())
     # Write empty dataframe
     empty_df = DataFrames.DataFrame()
-    write_df_to_csv_to_s3(
-        empty_df,
-        "empty_df.csv",
-        p"empty_df.csv",
-        bucket_name,
-        "empty_df.csv",
-    )
-    write_df_to_arrow_to_s3(
-        empty_df,
-        "empty_df.arrow",
-        p"empty_df.arrow",
-        bucket_name,
-        "empty_df.arrow",
-    )
+    if !ispath(S3Path("s3://$bucket_name/empty_df.csv", config = Banyan.get_aws_config())
+        write_df_to_csv_to_s3(
+            empty_df,
+            "empty_df.csv",
+            p"empty_df.csv",
+            bucket_name,
+            "empty_df.csv",
+        )
+    end
+    if !ispath(S3Path("s3://$bucket_name/empty_df.arrow", config = Banyan.get_aws_config())
+        write_df_to_arrow_to_s3(
+            empty_df,
+            "empty_df.arrow",
+            p"empty_df.arrow",
+            bucket_name,
+            "empty_df.arrow",
+        )
+    end
 
     # Write empty dataframe with two columns
     empty_df2 = DataFrames.DataFrame(x = [], y = [])
-    write_df_to_csv_to_s3(
-        empty_df2,
-        "empty_df2.csv",
-        p"empty_df2.csv",
-        bucket_name,
-        "empty_df2.csv",
-    )
-    write_df_to_arrow_to_s3(
-        empty_df2,
-        "empty_df2.arrow",
-        p"empty_df2.arrow",
-        bucket_name,
-        "empty_df2.arrow",
-    )
+    if !ispath(S3Path("s3://$bucket_name/empty_df2.csv", config = Banyan.get_aws_config())
+        write_df_to_csv_to_s3(
+            empty_df2,
+            "empty_df2.csv",
+            p"empty_df2.csv",
+            bucket_name,
+            "empty_df2.csv",
+        )
+    end
+    if !ispath(S3Path("s3://$bucket_name/empty_df2.arrow", config = Banyan.get_aws_config())
+        write_df_to_arrow_to_s3(
+            empty_df2,
+            "empty_df2.arrow",
+            p"empty_df2.arrow",
+            bucket_name,
+            "empty_df2.arrow",
+        )
+    end
 end
 
 global n_repeats = 10


### PR DESCRIPTION
* Test reading in an empty file (blank file with no contents) and writing it out
* (1) but with an empty directory
* Test filtering a CSV dataset (so that its empty) and then writing the result to a file
* Test fFiltering a CSV dataset (so that its empty) and then doing a groupby-subset and writing the result to a file
* (3) and (4) but filtering to a single row
* Test getting a column (which would be a Banyan array) and collecting a reduce (using init) result?

All of the above should for the 3 different kinds of scheduling_configs and for the 3 kinds of files (csv, parquet, arrow)