### PR TITLE
Fix several issues

### DIFF
--- a/Banyan/src/jobs.jl
+++ b/Banyan/src/jobs.jl
@@ -286,7 +286,7 @@ function wait_for_job(job_id::JobId=get_job_id())
             @info "Job $job_id is ready for computation"
             return
         elseif message_type == "JOB_FAILURE"
-            throw(ErrorException("Job $job_id has failed"))
+            error("Job $job_id has failed")
         end
     end
 end

--- a/Banyan/src/jobs.jl
+++ b/Banyan/src/jobs.jl
@@ -137,7 +137,7 @@ function create_job(;
         environment_info["force_pull"] = force_pull
         environment_info["force_install"] = force_install
         environment_info["environment_hash"] = get_hash(
-            url * directory * (if isnothing(branch) "" else branch end)
+            url * (if isnothing(branch) "" else branch end)
         )
     end
     job_configuration["environment_info"] = environment_info
@@ -286,7 +286,7 @@ function wait_for_job(job_id::JobId=get_job_id())
             @info "Job $job_id is ready for computation"
             return
         elseif message_type == "JOB_FAILURE"
-            @error "Job $job_id has failed"
+            throw(ErrorException("Job $job_id has failed"))
         end
     end
 end

--- a/Banyan/src/requests.jl
+++ b/Banyan/src/requests.jl
@@ -391,6 +391,9 @@ function send_evaluation(value_id::ValueId, job_id::JobId)
             "packages" => vcat(used_packages, get_loaded_packages())
         ),
     )
+    if isnothing(response)
+        throw(ErrorException("The evaluation request has failed. Please contact support"))
+    end
 
     @show response
 

--- a/Banyan/src/utils.jl
+++ b/Banyan/src/utils.jl
@@ -371,18 +371,18 @@ function send_request_get_response(method, content::Dict)
 	    url, input=IOBuffer(JSON.json(content)), method="POST", headers=headers
     )
     if resp.status == 403
-        throw(ErrorException("Please use a valid user ID and API key. Sign into the dashboard to retrieve these credentials."))
+        error("Please use a valid user ID and API key. Sign into the dashboard to retrieve these credentials.")
     elseif resp.status == 504
         # HTTP request timed out, for example
         if isa(data, Dict) && haskey(data, "message")
             data = data["message"]
         end
-        @warn data
+        @error data
         return nothing
     elseif resp.status == 500 || resp.status == 504
-        throw(ErrorException(data))
+        error(data)
     elseif resp.status == 502
-        throw(ErrorException("Sorry there has been an error. Please contact support"))
+        error("Sorry there has been an error. Please contact support")
     end
     return data
 

--- a/Banyan/src/utils.jl
+++ b/Banyan/src/utils.jl
@@ -346,6 +346,16 @@ function request_json(url::AbstractString; kwargs...)
     return resp, JSON.parse(body)
 end
 
+# Sends an HTTP request to the Banyan API and returns the
+# parsed response. Sends the provided content as the body of
+# the message and additionally adds the User ID and API Key,
+# which are required on all requests for authentication. Additionally,
+# a debug flag is sent. An exception is thrown is the HTTP
+# requests returns  a 403, 500, or 504 HTTP error cdode. If the
+# request times out, a warning message is printed out and `nothing`
+# is returned.
+# It is up to the caller to handle the case where the HTTP request
+# times out and `nothing` is returned.
 function send_request_get_response(method, content::Dict)
     # Prepare request
     configuration = load_config()
@@ -367,7 +377,8 @@ function send_request_get_response(method, content::Dict)
         if isa(data, Dict) && haskey(data, "message")
             data = data["message"]
         end
-        @info data
+        @warn data
+        return nothing
     elseif resp.status == 500 || resp.status == 504
         throw(ErrorException(data))
     elseif resp.status == 502


### PR DESCRIPTION
* When the environment is in a remote Github repository, compute environment hash based the URL and the branch, not the directory. Different URL indicates different environments. Since, we checkout the branch, we must clone the repository multiple times for each branch, so that we can allow multiple users to use different branches of the same repository each time.
* Make `send_request_get_response` to return print a warning message and return `nothing` if the HTTP request times out. This request the caller to handle the case where `nothing` is returned. Modified `send_evaluation` to handle this case.
