### PR TITLE
Optimizations for job creation

### DIFF
--- a/Banyan/src/jobs.jl
+++ b/Banyan/src/jobs.jl
@@ -49,6 +49,7 @@ function create_job(;
     code_files::Union{Vector,Nothing} = [],
     force_update_files::Union{Bool,Nothing} = false,
     pf_dispatch_table::Union{String,Nothing} = "",
+    used_packages::Union{Vector,Nothing} = [],
     url::Union{String,Nothing} = nothing,
     branch::Union{String,Nothing} = nothing,
     directory::Union{String,Nothing} = nothing,
@@ -91,7 +92,7 @@ function create_job(;
 	    "store_logs_in_s3" => store_logs_in_s3,
         "store_logs_on_cluster" => store_logs_on_cluster,
         "julia_version" => julia_version,
-        "nowait" => nowait
+        "used_packages" => vcat(get_loaded_modules(), used_packages)
     )
     if !isnothing(job_name)
         job_configuration["job_name"] = job_name

--- a/Banyan/src/jobs.jl
+++ b/Banyan/src/jobs.jl
@@ -49,7 +49,7 @@ function create_job(;
     code_files::Union{Vector,Nothing} = [],
     force_update_files::Union{Bool,Nothing} = false,
     pf_dispatch_table::Union{String,Nothing} = "",
-    used_packages::Union{Vector,Nothing} = [],
+    using_modules::Union{Vector,Nothing} = [],
     url::Union{String,Nothing} = nothing,
     branch::Union{String,Nothing} = nothing,
     directory::Union{String,Nothing} = nothing,
@@ -92,7 +92,8 @@ function create_job(;
 	    "store_logs_in_s3" => store_logs_in_s3,
         "store_logs_on_cluster" => store_logs_on_cluster,
         "julia_version" => julia_version,
-        "used_packages" => vcat(get_loaded_modules(), used_packages)
+        "main_modules" => get_loaded_packages(),
+        "using_modules" => using_modules,
     )
     if !isnothing(job_name)
         job_configuration["job_name"] = job_name

--- a/Banyan/src/requests.jl
+++ b/Banyan/src/requests.jl
@@ -389,9 +389,9 @@ function send_evaluation(value_id::ValueId, job_id::JobId)
                 "exaggurate_size" => exaggurate_size
             ),
             "num_bang_values_issued" => get_num_bang_values_issued(),
-            # "main_packages" => get_loaded_packages(),
-            # "used_packages" => used_packages,
-            "packages" => vcat(used_packages, get_loaded_packages())
+            "main_modules" => get_loaded_packages(),
+            "partitioned_using_modules" => used_packages,
+            # "packages" => vcat(used_packages, get_loaded_packages())
         ),
     )
     if isnothing(response)


### PR DESCRIPTION
This PR adds 2 main things:
1. Adds the parameter `using_modules` to create_job. This allows one to specify modules to add/import on job creation, which can reduce time later when an evaluation request is sent. The currently used packages are also determined at job creation and sent to import on the cluster, which reduces the time of the first evaluation request spent in Pkg.adding or `using` modules.
2. Saves all used modules for each job, so that the `using` statements are run only once for each job.