### PR TITLE
Ensure job is running before sending evaluate

### DIFF
--- a/Banyan/src/jobs.jl
+++ b/Banyan/src/jobs.jl
@@ -91,7 +91,7 @@ function create_job(;
         "store_logs_on_cluster" => store_logs_on_cluster,
         "julia_version" => julia_version,
         "nowait" => nowait,
-        "benchmark" => get(ENV, "BANYAN_BENCHMARK", "0") == "1"
+        "benchmark" => get(ENV, "BANYAN_BENCHMARK", "0") == "1",
         "main_modules" => get_loaded_packages(),
         "using_modules" => using_modules,
     )

--- a/Banyan/src/jobs.jl
+++ b/Banyan/src/jobs.jl
@@ -49,6 +49,7 @@ function create_job(;
     code_files::Union{Vector,Nothing} = [],
     force_update_files::Union{Bool,Nothing} = false,
     pf_dispatch_table::Union{String,Nothing} = "",
+    used_packages::Union{Vector,Nothing} = [],
     url::Union{String,Nothing} = nothing,
     branch::Union{String,Nothing} = nothing,
     directory::Union{String,Nothing} = nothing,
@@ -91,6 +92,7 @@ function create_job(;
         "julia_version" => julia_version,
         "nowait" => nowait,
         "benchmark" => get(ENV, "BANYAN_BENCHMARK", "0") == "1"
+        "used_packages" => vcat(get_loaded_modules(), used_packages)
     )
     if !isnothing(job_name)
         job_configuration["job_name"] = job_name

--- a/Banyan/src/jobs.jl
+++ b/Banyan/src/jobs.jl
@@ -49,7 +49,7 @@ function create_job(;
     code_files::Union{Vector,Nothing} = [],
     force_update_files::Union{Bool,Nothing} = false,
     pf_dispatch_table::Union{String,Nothing} = "",
-    used_packages::Union{Vector,Nothing} = [],
+    using_modules::Union{Vector,Nothing} = [],
     url::Union{String,Nothing} = nothing,
     branch::Union{String,Nothing} = nothing,
     directory::Union{String,Nothing} = nothing,
@@ -92,7 +92,8 @@ function create_job(;
         "julia_version" => julia_version,
         "nowait" => nowait,
         "benchmark" => get(ENV, "BANYAN_BENCHMARK", "0") == "1"
-        "used_packages" => vcat(get_loaded_modules(), used_packages)
+        "main_modules" => get_loaded_packages(),
+        "using_modules" => using_modules,
     )
     if !isnothing(job_name)
         job_configuration["job_name"] = job_name

--- a/Banyan/src/requests.jl
+++ b/Banyan/src/requests.jl
@@ -326,6 +326,11 @@ function send_evaluation(value_id::ValueId, job_id::JobId)
     global encourage_parallelism_with_batches
     global exaggurate_size
 
+    # First, ensure that the job is running
+    wait_for_job(job_id)
+
+    @debug "Sending evaluation request"
+
     # Get list of the modules used in the code regions here
     used_packages = union(vcat([req.task.used_modules for req in get_job().pending_requests if req isa RecordTaskRequest]...))
 

--- a/Banyan/src/requests.jl
+++ b/Banyan/src/requests.jl
@@ -326,8 +326,10 @@ function send_evaluation(value_id::ValueId, job_id::JobId)
     global encourage_parallelism_with_batches
     global exaggurate_size
 
-    # First, ensure that the job is running
-    wait_for_job(job_id)
+    # Note that we do not need to check if the job is running here, because
+    # `evaluate` will check if the job has failed. If the job is still creating,
+    # we will proceed with the eval request, but the client side will wait
+    # for the job to be ready when reading from the queue.
 
     @debug "Sending evaluation request"
 
@@ -351,7 +353,6 @@ function send_evaluation(value_id::ValueId, job_id::JobId)
             "main_modules" => get_loaded_packages(),
             "partitioned_using_modules" => used_packages,
             "benchmark" => get(ENV, "BANYAN_BENCHMARK", "0") == "1"
-            # "packages" => vcat(used_packages, get_loaded_packages())
         ),
     )
     if isnothing(response)


### PR DESCRIPTION
This PR ensures that the job is running before sending an evaluation request. The nowait parameter only affects what happens when the function `create_job` is called. It has no other effect on the job.
Depends on #75 