### PR TITLE
Optimize calls to describe_clusters

### DIFF
--- a/Banyan/src/clusters.jl
+++ b/Banyan/src/clusters.jl
@@ -208,7 +208,7 @@ get_running_clusters(args...; kwargs...) = filter(entry -> entry[2].status == :r
 
 function get_cluster_status(name::String=get_cluster_name(), kwargs...)
     global clusters
-    if !haskey(clusters, name)
+    if haskey(clusters, name)
         if clusters[name].status == :failed
             @error c.status_explanation
         end

--- a/Banyan/src/clusters.jl
+++ b/Banyan/src/clusters.jl
@@ -1,3 +1,6 @@
+# Process-local dictionary mapping from cluster names to instances of `Cluster`
+# Might contain stale information
+global clusters = Dict()
 
 function create_cluster(;
     name::Union{String,Nothing} = nothing,
@@ -87,7 +90,12 @@ function create_cluster(;
         wait_for_cluster(name)
     end
 
-    return Cluster(name, get_cluster_status(name), "", 0, s3_bucket_arn)
+    # Cache info
+    global clusters
+    cl = Cluster(name, get_cluster_status(name), "", 0, s3_bucket_arn)
+    clusters[name] = cl
+
+    return cl
 end
 
 function destroy_cluster(name::String; kwargs...)
@@ -152,11 +160,15 @@ parsestatus(status) =
         error("Unexpected status ", status)
     end
 
-function get_clusters(; kwargs...)
+function get_clusters(cluster_name=nothing; kwargs...)
     @debug "Downloading description of clusters"
     configure(; kwargs...)
-    response = send_request_get_response(:describe_clusters, Dict{String,Any}())
-    Dict(
+    filters = Dict()
+    if !isnothing(cluster_name)
+        filters["cluster_name"] = cluster_name
+    end
+    response = send_request_get_response(:describe_clusters, Dict{String,Any}("filters"=>filters))
+    clusters_dict = Dict(
         name => Cluster(
             name,
             parsestatus(c["status"]),
@@ -165,20 +177,43 @@ function get_clusters(; kwargs...)
             c["s3_read_write_resource"],
         ) for (name, c) in response["clusters"]
     )
+
+    # Cache info
+    global clusters
+    for (name, c) in clusters_dict
+        clusters[name] = c
+    end
+
+    return clusters_dict
+end
+
+function get_cluster_s3_bucket_arn(cluster_name=get_cluster_name(); kwargs...)
+    configure(; kwargs...)
+    global clusters
+    # Check if cached, sine this property is immutable
+    if !haskey(clusters, cluster_name)
+        get_cluster(cluster_name)
+    end
+    return clusters[cluster_name].s3_bucket_arn
 end
 
 function get_cluster_s3_bucket_name(cluster_name=get_cluster_name(); kwargs...)
     configure(; kwargs...)
-    cluster = get_cluster(cluster_name)
-    return s3_bucket_arn_to_name(cluster.s3_bucket_arn)
+    return s3_bucket_arn_to_name(get_cluster_s3_bucket_arn(cluster_name))
 end
 
-get_cluster(name::String=get_cluster_name(), kwargs...) = get_clusters(; kwargs...)[name]
+get_cluster(name::String=get_cluster_name(), kwargs...) = get_clusters(name; kwargs...)[name]
 
 get_running_clusters(args...; kwargs...) = filter(entry -> entry[2].status == :running, get_clusters(args...; kwargs...))
 
 function get_cluster_status(name::String=get_cluster_name(), kwargs...)
-    c = get_clusters(; kwargs...)[name]
+    global clusters
+    if !haskey(clusters, name)
+        if clusters[name].status == :failed
+            @error c.status_explanation
+        end
+    end
+    c = get_cluster(name; kwargs...)
     if c.status == :failed
         @error c.status_explanation
     end

--- a/Banyan/src/jobs.jl
+++ b/Banyan/src/jobs.jl
@@ -248,8 +248,7 @@ get_running_jobs(args...; kwargs...) = get_jobs(args...; status="running", kwarg
 function download_job_logs(job_id::JobId, cluster_name::String, filename::String=nothing; kwargs...)
     @debug "Downloading logs for job"
     configure(; kwargs...)
-    s3_bucket_arn = get_cluster(cluster_name).s3_bucket_arn
-    s3_bucket_name = s3_bucket_arn_to_name(s3_bucket_arn)
+    s3_bucket_name = get_cluster_s3_bucket_name(cluster_name)
     log_file_name = "banyan-log-for-job-$(job_id)"
     filename = !isnothing(filename) ? filename : joinpath(homedir(), ".banyan", "logs")
     s3_get_file(get_aws_config(), s3_bucket_name, log_file_name, filename)

--- a/Banyan/src/utils_s3fs.jl
+++ b/Banyan/src/utils_s3fs.jl
@@ -1,8 +1,8 @@
 get_s3_bucket_arn(cluster_name) = get_cluster(cluster_name).s3_bucket_arn
 get_s3_bucket_path(cluster_name) =
-    replace(get_cluster(cluster_name).s3_bucket_arn, "arn:aws:s3:::" => "s3://")
+    replace(get_cluster_s3_bucket_arn(), "arn:aws:s3:::" => "s3://")
 function get_s3fs_bucket_path(cluster_name)
-    arn = get_cluster(cluster_name).s3_bucket_arn
+    arn = get_cluster_s3_bucket_arn()
     joinpath(
         homedir(),
         ".banyan",

--- a/BanyanDataFrames/Manifest.toml
+++ b/BanyanDataFrames/Manifest.toml
@@ -43,7 +43,7 @@ version = "1.2.1"
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [[Banyan]]
-deps = ["AWS", "AWSCore", "AWSS3", "AWSSQS", "Arrow", "Base64", "CSV", "DataFrames", "Downloads", "FileIO", "FilePathsBase", "HDF5", "HTTP", "IniFile", "IterTools", "JSON", "MPI", "Parquet", "Pkg", "Random", "SHA", "Serialization", "TOML", "TimeZones"]
+deps = ["AWS", "AWSCore", "AWSS3", "AWSSQS", "Arrow", "Base64", "CSV", "DataFrames", "Dates", "Downloads", "FileIO", "FilePathsBase", "HDF5", "HTTP", "IniFile", "IterTools", "JSON", "MPI", "Parquet", "Pkg", "ProgressMeter", "Random", "SHA", "Serialization", "TOML", "TimeZones"]
 path = "../Banyan"
 uuid = "706d138b-e922-45b9-a636-baf8ae0d5317"
 version = "0.1.3"
@@ -337,9 +337,9 @@ version = "0.19.0"
 
 [[MPICH_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "c6cafe3f9747c0a0740611e2dffc4d37248fb691"
+git-tree-sha1 = "09864c823da1a606dbc151534c1a134fd5506170"
 uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
-version = "3.4.2+0"
+version = "3.4.2+1"
 
 [[Markdown]]
 deps = ["Base64"]
@@ -357,9 +357,9 @@ uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 
 [[MicrosoftMPI_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "e5c90234b3967684c9c6f87b4a54549b4ce21836"
+git-tree-sha1 = "bb2fe65544e6efd883bb2060088df7dfb7273b41"
 uuid = "9237b28f-5490-5468-be7b-bb81f5f5e6cf"
-version = "10.1.3+0"
+version = "10.1.3+1"
 
 [[Missings]]
 deps = ["DataAPI"]
@@ -384,9 +384,9 @@ uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
 [[OpenMPI_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "a784e5133fc7e204c900f2cf38ed37a92ff9248d"
+git-tree-sha1 = "872077914c8a8cab9ea1430f338ae6b59258577d"
 uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
-version = "4.1.1+2"
+version = "4.1.1+3"
 
 [[OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -436,6 +436,12 @@ version = "1.2.2"
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[ProgressMeter]]
+deps = ["Distributed", "Printf"]
+git-tree-sha1 = "afadeba63d90ff223a6a48d2009434ecee2ec9e8"
+uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
+version = "1.7.1"
 
 [[PropertyDicts]]
 git-tree-sha1 = "429d887daee312e73842cabe6b122e310b72e25d"


### PR DESCRIPTION
This PR ensures that we only download info for a single cluster, if cluster name is specified, and that we cache immutable information (such as the s3 bucket arn) on the client side.