### PR TITLE
Fix issue with downloads.jl timing out after 20 seconds

### DIFF
--- a/Banyan/src/Banyan.jl
+++ b/Banyan/src/Banyan.jl
@@ -162,7 +162,6 @@ using Serialization, Base64, MPI
 # For loading
 using ProgressMeter
 
-
 # Helpers
 include("id.jl")
 include("utils_queues.jl")

--- a/Banyan/src/Banyan.jl
+++ b/Banyan/src/Banyan.jl
@@ -162,6 +162,7 @@ using Serialization, Base64, MPI
 # For loading
 using ProgressMeter
 
+
 # Helpers
 include("id.jl")
 include("utils_queues.jl")
@@ -212,6 +213,12 @@ function __init__()
 
     global BANYAN_API_ENDPOINT
     BANYAN_API_ENDPOINT = "https://hcohsbhhzf.execute-api.us-west-2.amazonaws.com/dev/"
+
+    # Downloads settings
+    global downloader
+    downloader = Downloads.Downloader()
+    downloader.easy_hook = (easy, info) ->
+       Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_LOW_SPEED_TIME, 40)
 
     load_config()
 end

--- a/Banyan/src/utils.jl
+++ b/Banyan/src/utils.jl
@@ -333,7 +333,7 @@ function request_body(url::AbstractString; kwargs...)
     global downloader
     resp = nothing
     body = sprint() do output
-        @time resp = request(url; output=output, throw=false, downloader=downloader, kwargs...)
+        resp = request(url; output=output, throw=false, downloader=downloader, kwargs...)
     end
     return resp, body
 end

--- a/Banyan/src/utils.jl
+++ b/Banyan/src/utils.jl
@@ -330,9 +330,10 @@ end
 Sends given request with given content
 """
 function request_body(url::AbstractString; kwargs...)
+    global downloader
     resp = nothing
     body = sprint() do output
-        resp = request(url; output=output, kwargs...)
+        @time resp = request(url; output=output, throw=false, downloader=downloader, kwargs...)
     end
     return resp, body
 end


### PR DESCRIPTION
Set parameter in libcurl to not timeout after 20 seconds. This allows us to properly receive the 504 timeout error from the API Gateway.