### PR TITLE
Ranges, `getindex`, and `compute_inplace`

### DIFF
--- a/Banyan/src/Banyan.jl
+++ b/Banyan/src/Banyan.jl
@@ -20,6 +20,7 @@ using AWSCore
 using AWSS3
 using AWSSQS
 using Base64
+using Dates
 using Downloads
 using HTTP
 using JSON

--- a/Banyan/src/Banyan.jl
+++ b/Banyan/src/Banyan.jl
@@ -78,7 +78,7 @@ export Session,
     download_session_logs
 
 # Futures
-export AbstractFuture, Future, partitioned_computation, write_to_disk, compute
+export AbstractFuture, Future, partitioned_computation, compute_inplace, compute
 
 # Samples
 export Sample, ExactSample, sample, setsample!

--- a/Banyan/src/annotation.jl
+++ b/Banyan/src/annotation.jl
@@ -377,7 +377,7 @@ end
 # Macro for wrapping the code region to offload #
 #################################################
 
-function apply_mutation(mutation::Dict{Future,Future})
+function apply_mutation(mutation#==::Dict{Future,Future}==#)
     for (old, new) in mutation
         if old != new
             # Apply the mutation by setting the value ID of the old future the
@@ -433,7 +433,7 @@ function apply_mutation(mutation::Dict{Future,Future})
     end
 end
 
-invert(mutation::Dict{Future,Future}) = Dict(new => old for (old, new) in mutation)
+invert(mutation#==::Dict{Future,Future}==#) = Dict(new => old for (old, new) in mutation)
 
 function partitioned_using_modules(m...)
     global curr_delayed_task

--- a/Banyan/src/annotation.jl
+++ b/Banyan/src/annotation.jl
@@ -377,7 +377,7 @@ end
 # Macro for wrapping the code region to offload #
 #################################################
 
-function apply_mutation(mutation#==::Dict{Future,Future}==#)
+function apply_mutation(mutation::Dict{Future,Future})
     for (old, new) in mutation
         if old != new
             # Apply the mutation by setting the value ID of the old future the
@@ -433,7 +433,7 @@ function apply_mutation(mutation#==::Dict{Future,Future}==#)
     end
 end
 
-invert(mutation#==::Dict{Future,Future}==#) = Dict(new => old for (old, new) in mutation)
+invert(mutation::Dict{Future,Future}) = Dict(new => old for (old, new) in mutation)
 
 function partitioned_using_modules(m...)
     global curr_delayed_task

--- a/Banyan/src/locations.jl
+++ b/Banyan/src/locations.jl
@@ -469,7 +469,7 @@ end
 function convert_to_unpooled(A)
     type_name = typeof(A).name.name
     if type_name == :PooledArray
-        collect(A)
+        Base.collect(A)
     elseif type_name == :CategoricalArray
         unwrap.(A)
     else

--- a/Banyan/src/pfs.jl
+++ b/Banyan/src/pfs.jl
@@ -539,7 +539,7 @@ function Reduce(
         op,
         comm,
     )
-    println("In Reduce after Allreduce with part=$part and src=$src on get_worker_idx(comm)=$(get_worker_idx(comm)) with src_params=$src_params")
+    println("In Reduce after Allreduce with part=$part on get_worker_idx(comm)=$(get_worker_idx(comm)) with src_params=$src_params")
     part
 end
 

--- a/Banyan/src/pfs.jl
+++ b/Banyan/src/pfs.jl
@@ -132,6 +132,7 @@ ReadGroup(ReadBlock) = begin
 
             # Shuffle the batch and add it to the set of data for this partition
             params["divisions_by_worker"] = curr_partition_divisions
+            println("Before Shuffle in ReadGroup")
             push!(
                 parts,
                 Shuffle(
@@ -144,11 +145,13 @@ ReadGroup(ReadBlock) = begin
                     store_splitting_divisions = false
                 ),
             )
+            println("After Shuffle in ReadGroup")
             delete!(params, "divisions_by_worker")
         end
 
         # Concatenate together the data for this partition
         res = merge_on_executor(parts...; key = key)
+        println("After merge_on_executor in ReadGroup")
 
         # If there are no divisions for any of the partitions, then they are all
         # bounded. For a partition to be unbounded on one side, there must be a
@@ -159,6 +162,7 @@ ReadGroup(ReadBlock) = begin
         partition_idx = get_partition_idx(batch_idx, nbatches, comm)
         splitting_divisions[res] =
             (partition_divisions[partition_idx], !hasdivision || partition_idx != firstdivisionidx, !hasdivision || partition_idx != lastdivisionidx)
+        println("At end of ReadGroup")
 
         res
     end

--- a/Banyan/src/pfs.jl
+++ b/Banyan/src/pfs.jl
@@ -39,7 +39,7 @@ function sortablestring(val, maxval)
     s = string(val)
     maxs = string(maxval)
     res = Base.fill('0', length(maxs))
-    res[length(res)-length(s)+1:length(res)] .= collect(s)
+    res[length(res)-length(s)+1:length(res)] .= Base.collect(s)
     join(res)
 end
 

--- a/Banyan/src/pfs.jl
+++ b/Banyan/src/pfs.jl
@@ -428,6 +428,16 @@ end
 
 ReduceWithKeyAndCopyToJulia = ReduceAndCopyToJulia
 
+Divide(
+    src::AbstractRange,
+    params::Dict{String,Any},
+    batch_idx::Integer,
+    nbatches::Integer,
+    comm::MPI.Comm,
+    loc_name::String,
+    loc_params::Dict{String,Any},
+) = src[split_len(length(src), batch_idx, nbatches, comm)]
+
 function Divide(
     src::Tuple,
     params::Dict{String,Any},
@@ -437,6 +447,7 @@ function Divide(
     loc_name::String,
     loc_params::Dict{String,Any},
 )
+    # This is for sizes which are tuples.
     dim = params["key"]
     part = src
     # part = CopyFrom(src, params, batch_idx, nbatches, comm, loc_name, loc_params)

--- a/Banyan/src/pfs.jl
+++ b/Banyan/src/pfs.jl
@@ -290,7 +290,10 @@ CopyFromValue(
     comm::MPI.Comm,
     loc_name,
     loc_params,
-) = loc_params["value"]
+) = begin
+    println("In CopyFromValue")
+    loc_params["value"]
+end
 
 CopyFromClient(
     src,

--- a/Banyan/src/pfs.jl
+++ b/Banyan/src/pfs.jl
@@ -404,7 +404,7 @@ function ReduceAndCopyToJulia(
     # TODO: Ensure that we handle reductions that can produce nothing
     src = reduce_in_memory(src, part, op)
 
-    println("In ReduceAndCopyToJulia with src=$src and part=$part and batch_idx=$batch_idx and nbatches=$nbatches and loc_name=$loc_name and params=$params with loc_params=$loc_params")
+    println("In ReduceAndCopyToJulia with src=$src and part=$part and batch $batch_idx/$nbatches on  on worker $(get_worker_idx(comm))/$(get_nworkers(comm)) and rank $(MPI.Comm_rank(comm))/$(MPI.Comm_size(comm)) params=$params with loc_params=$loc_params for loc_name=$loc_name")
 
     # Merge reductions across workers
     if batch_idx == nbatches
@@ -528,7 +528,7 @@ function Reduce(
     # sendbuf and where sendbuf is not isbitstype
 
     # Perform reduction
-    println("In Reduce before Allreduce with part=$part on get_worker_idx(comm)=$(get_worker_idx(comm)) with src_params=$src_params")
+    println("In Reduce before Allreduce with part=$part on worker $(get_worker_idx(comm))/$(get_nworkers(comm)) and rank $(MPI.Comm_rank(comm))/$(MPI.Comm_size(comm)) with src_params=$src_params")
     part = MPI.Allreduce(
         part,
         # sendbuf,
@@ -539,7 +539,7 @@ function Reduce(
         op,
         comm,
     )
-    println("In Reduce after Allreduce with part=$part on get_worker_idx(comm)=$(get_worker_idx(comm)) with src_params=$src_params")
+    println("In Reduce after Allreduce with part=$part on worker $(get_worker_idx(comm))/$(get_nworkers(comm)) and rank $(MPI.Comm_rank(comm))/$(MPI.Comm_size(comm)) with src_params=$src_params")
     part
 end
 

--- a/Banyan/src/pfs.jl
+++ b/Banyan/src/pfs.jl
@@ -404,6 +404,8 @@ function ReduceAndCopyToJulia(
     # TODO: Ensure that we handle reductions that can produce nothing
     src = reduce_in_memory(src, part, op)
 
+    println("In ReduceAndCopyToJulia with src=$src and part=$part and batch_idx=$batch_idx and nbatches=$nbatches and loc_name=$loc_name")
+
     # Merge reductions across workers
     if batch_idx == nbatches
         src = Reduce(src, params, Dict{String,Any}(), comm)
@@ -526,6 +528,7 @@ function Reduce(
     # sendbuf and where sendbuf is not isbitstype
 
     # Perform reduction
+    println("In Reduce before Allreduce with part=$part and src=$src on get_worker_idx(comm)=$(get_worker_idx(comm))")
     part = MPI.Allreduce(
         part,
         # sendbuf,
@@ -536,6 +539,7 @@ function Reduce(
         op,
         comm,
     )
+    println("In Reduce after Allreduce with part=$part and src=$src on get_worker_idx(comm)=$(get_worker_idx(comm))")
     part
 end
 

--- a/Banyan/src/pfs.jl
+++ b/Banyan/src/pfs.jl
@@ -132,7 +132,7 @@ ReadGroup(ReadBlock) = begin
 
             # Shuffle the batch and add it to the set of data for this partition
             params["divisions_by_worker"] = curr_partition_divisions
-            println("Before Shuffle in ReadGroup")
+            println("Before Shuffle in ReadGroup with typeof(part)=$(typeof(part))")
             push!(
                 parts,
                 Shuffle(

--- a/Banyan/src/pfs.jl
+++ b/Banyan/src/pfs.jl
@@ -346,7 +346,7 @@ CopyToClient(
     send_to_client(loc_params["value_id"], part)
 end
 
-CopyToJulia(
+function CopyToJulia(
     src,
     part,
     params,
@@ -355,14 +355,19 @@ CopyToJulia(
     comm::MPI.Comm,
     loc_name,
     loc_params,
-) = if get_partition_idx(batch_idx, nbatches, comm) == 1
-    # # This must be on disk; we don't support Julia serialized objects
-    # # as a remote location yet. We will need to first refactor locations
-    # # before we add support for that.
-    # if isa_gdf(part)
-    #     part = nothing
-    # end
-    serialize(getpath(loc_params["path"], comm), part)
+)
+    if get_partition_idx(batch_idx, nbatches, comm) == 1
+        # # This must be on disk; we don't support Julia serialized objects
+        # # as a remote location yet. We will need to first refactor locations
+        # # before we add support for that.
+        # if isa_gdf(part)
+        #     part = nothing
+        # end
+        serialize(getpath(loc_params["path"], comm), part)
+    end
+    if get_worker_idx(comm) == 1
+        MPI.Barrier(comm)
+    end
 end
 
 function get_op!(params::Dict{String,Any})

--- a/Banyan/src/pfs.jl
+++ b/Banyan/src/pfs.jl
@@ -132,7 +132,6 @@ ReadGroup(ReadBlock) = begin
 
             # Shuffle the batch and add it to the set of data for this partition
             params["divisions_by_worker"] = curr_partition_divisions
-            println("Before Shuffle in ReadGroup with typeof(part)=$(typeof(part))")
             push!(
                 parts,
                 Shuffle(
@@ -145,13 +144,11 @@ ReadGroup(ReadBlock) = begin
                     store_splitting_divisions = false
                 ),
             )
-            println("After Shuffle in ReadGroup")
             delete!(params, "divisions_by_worker")
         end
 
         # Concatenate together the data for this partition
         res = merge_on_executor(parts...; key = key)
-        println("After merge_on_executor in ReadGroup")
 
         # If there are no divisions for any of the partitions, then they are all
         # bounded. For a partition to be unbounded on one side, there must be a
@@ -162,7 +159,6 @@ ReadGroup(ReadBlock) = begin
         partition_idx = get_partition_idx(batch_idx, nbatches, comm)
         splitting_divisions[res] =
             (partition_divisions[partition_idx], !hasdivision || partition_idx != firstdivisionidx, !hasdivision || partition_idx != lastdivisionidx)
-        println("At end of ReadGroup")
 
         res
     end
@@ -294,10 +290,7 @@ CopyFromValue(
     comm::MPI.Comm,
     loc_name,
     loc_params,
-) = begin
-    println("In CopyFromValue")
-    loc_params["value"]
-end
+) = loc_params["value"]
 
 CopyFromClient(
     src,

--- a/Banyan/src/pfs.jl
+++ b/Banyan/src/pfs.jl
@@ -409,8 +409,6 @@ function ReduceAndCopyToJulia(
     # TODO: Ensure that we handle reductions that can produce nothing
     src = reduce_in_memory(src, part, op)
 
-    println("In ReduceAndCopyToJulia with src=$src and part=$part and batch $batch_idx/$nbatches on  on worker $(get_worker_idx(comm))/$(get_nworkers(comm)) and rank $(MPI.Comm_rank(comm))/$(MPI.Comm_size(comm)) params=$params with loc_params=$loc_params for loc_name=$loc_name")
-
     # Merge reductions across workers
     if batch_idx == nbatches
         src = Reduce(src, params, Dict{String,Any}(), comm)
@@ -533,7 +531,6 @@ function Reduce(
     # sendbuf and where sendbuf is not isbitstype
 
     # Perform reduction
-    println("In Reduce before Allreduce with part=$part on worker $(get_worker_idx(comm))/$(get_nworkers(comm)) and rank $(MPI.Comm_rank(comm))/$(MPI.Comm_size(comm)) with src_params=$src_params")
     part = MPI.Allreduce(
         part,
         # sendbuf,
@@ -544,7 +541,6 @@ function Reduce(
         op,
         comm,
     )
-    println("In Reduce after Allreduce with part=$part on worker $(get_worker_idx(comm))/$(get_nworkers(comm)) and rank $(MPI.Comm_rank(comm))/$(MPI.Comm_size(comm)) with src_params=$src_params")
     part
 end
 

--- a/Banyan/src/pfs.jl
+++ b/Banyan/src/pfs.jl
@@ -365,7 +365,7 @@ function CopyToJulia(
         # end
         serialize(getpath(loc_params["path"], comm), part)
     end
-    if get_worker_idx(comm) == 1
+    if batch_idx == 1
         MPI.Barrier(comm)
     end
 end

--- a/Banyan/src/pfs.jl
+++ b/Banyan/src/pfs.jl
@@ -404,7 +404,7 @@ function ReduceAndCopyToJulia(
     # TODO: Ensure that we handle reductions that can produce nothing
     src = reduce_in_memory(src, part, op)
 
-    println("In ReduceAndCopyToJulia with src=$src and part=$part and batch_idx=$batch_idx and nbatches=$nbatches and loc_name=$loc_name")
+    println("In ReduceAndCopyToJulia with src=$src and part=$part and batch_idx=$batch_idx and nbatches=$nbatches and loc_name=$loc_name and params=$params with loc_params=$loc_params")
 
     # Merge reductions across workers
     if batch_idx == nbatches
@@ -528,7 +528,7 @@ function Reduce(
     # sendbuf and where sendbuf is not isbitstype
 
     # Perform reduction
-    println("In Reduce before Allreduce with part=$part and src=$src on get_worker_idx(comm)=$(get_worker_idx(comm))")
+    println("In Reduce before Allreduce with part=$part on get_worker_idx(comm)=$(get_worker_idx(comm)) with src_params=$src_params")
     part = MPI.Allreduce(
         part,
         # sendbuf,
@@ -539,7 +539,7 @@ function Reduce(
         op,
         comm,
     )
-    println("In Reduce after Allreduce with part=$part and src=$src on get_worker_idx(comm)=$(get_worker_idx(comm))")
+    println("In Reduce after Allreduce with part=$part and src=$src on get_worker_idx(comm)=$(get_worker_idx(comm)) with src_params=$src_params")
     part
 end
 

--- a/Banyan/src/queues.jl
+++ b/Banyan/src/queues.jl
@@ -114,7 +114,7 @@ function receive_from_client(value_id)
         JSON.json(Dict("kind" => "SCATTER_REQUEST", "value_id" => value_id))
     )
     # Receive response from client
-    m = JSON.parse(get_next_message(get_scatter_queue()))
+    m = JSON.parse(get_next_message(get_scatter_queue())[1])
     v = from_jl_value_contents(m["contents"])
     v
 end

--- a/Banyan/src/requests.jl
+++ b/Banyan/src/requests.jl
@@ -289,9 +289,9 @@ function partitioned_computation(handler, fut::AbstractFuture; destination, new_
                     # the schedule to determine whether it is possible for the
                     # data to fit in memory, we can't be sure that it will be
                     # in memory. So this data should have first been written to
-                    # disk with `write_to_disk` and then only written to this
+                    # disk with `compute_inplace` and then only written to this
                     # unreadable location.
-                    @warn "Value with ID $(fut.value_id) has been written to a location that cannot be used as a source and it is not on disk. Please do not attempt to use this value again. If you wish to use it again, please write it to disk with `write_to_disk` before writing it to a location."
+                    @warn "Value with ID $(fut.value_id) has been written to a location that cannot be used as a source and it is not on disk. Please do not attempt to use this value again. If you wish to use it again, please write it to disk with `compute_inplace` before writing it to a location."
                 end
                 sourced(fut, destination)
             end
@@ -445,7 +445,7 @@ function compute(fut::AbstractFuture)
     fut.value
 end
 
-function write_to_disk(fut::AbstractFuture)
+function compute_inplace(fut::AbstractFuture)
     fut = convert(Future, fut)
 
     partitioned_computation(fut, destination=Disk()) do

--- a/Banyan/src/requests.jl
+++ b/Banyan/src/requests.jl
@@ -18,6 +18,27 @@
 #############################
 using Banyan
 
+function check_worker_stuck_error(message, error_for_main_stuck, error_for_main_stuck_time)
+    value_id = message["value_id"]
+    if value_id == -2 && isnothing(error_for_main_stuck_time)
+        error_for_main_stuck_msg = from_jl_value_contents(message["contents"])
+        if contains(error_for_main_stuck_msg, "session $(get_session_id())")
+            error_for_main_stuck = error_for_main_stuck_msg
+            error_for_main_stuck_time = Dates.now()
+        end
+    end
+    error_for_main_stuck, error_for_main_stuck_time
+end
+
+function check_worker_stuck(error_for_main_stuck, error_for_main_stuck_time)
+    if !isnothing(error_for_main_stuck) && !isnothing(error_for_main_stuck_time) && (Dates.now() - error_for_main_stuck_time) > Second(30)
+        println(error_for_main_stuck)
+        @warn "The above error occurred on some workers but other workers are still running. Please interrupt and end the session unless you expect that a lot of logs are being returned."
+        error_for_main_stuck = nothing
+    end
+    error_for_main_stuck
+end
+
 function partitioned_computation(handler, fut::AbstractFuture; destination, new_source=nothing)
     if isview(fut)
         error("Computing a view (such as a GroupedDataFrame) is not currently supported")
@@ -221,9 +242,11 @@ function partitioned_computation(handler, fut::AbstractFuture; destination, new_
         if get_session_status(session_id) != "running"
             wait_for_session(session_id)
         end
+        error_for_main_stuck = nothing
+        error_for_main_stuck_time = nothing
         while true
             # TODO: Use to_jl_value and from_jl_value to support Client
-            message = receive_next_message(gather_queue, p)
+            message, error_for_main_stuck = receive_next_message(gather_queue, p, error_for_main_stuck, error_for_main_stuck_time)
             message_type = message["kind"]
             if message_type == "SCATTER_REQUEST"
                 # Send scatter
@@ -254,6 +277,7 @@ function partitioned_computation(handler, fut::AbstractFuture; destination, new_
                     # TODO: Update stale/mutated here to avoid costly
                     # call to `send_evaluation`
                 end
+                error_for_main_stuck, error_for_main_stuck_time = check_worker_stuck_error(message, error_for_main_stuck, error_for_main_stuck_time)
             elseif message_type == "EVALUATION_END"
                 # @debug "End of evaluation"
                 if message["end"] == true
@@ -499,8 +523,9 @@ function offloaded(given_function, args...; distributed = false)
     session = get_session()
     gather_queue = get_gather_queue(session.resource_id)
     stored_message = nothing
+    error_for_main_stuck, error_for_main_stuck_time = nothing, nothing
     while true
-        message = receive_next_message(gather_queue, p)
+        message, error_for_main_stuck = receive_next_message(gather_queue, p, error_for_main_stuck, error_for_main_stuck_time)
         message_type = message["kind"]
         if (message_type == "GATHER")
             value_id = message["value_id"]
@@ -509,6 +534,7 @@ function offloaded(given_function, args...; distributed = false)
             if (value_id == -1)
                 stored_message = from_jl_value_contents(message["contents"])
             end
+            error_for_main_stuck, error_for_main_stuck_time = check_worker_stuck_error(message, error_for_main_stuck, error_for_main_stuck_time)
         elseif (message_type == "EVALUATION_END")
             return stored_message
         end

--- a/Banyan/src/sessions.jl
+++ b/Banyan/src/sessions.jl
@@ -329,6 +329,10 @@ function get_session_status(session_id::String=get_session_id(); kwargs...)
     configure(; kwargs...)
     filters = Dict("session_id" => session_id)
     response = send_request_get_response(:describe_sessions, Dict{String,Any}("filters"=>filters))
+    if !haskey(response["sessions"], session_id)
+        @warn "Session with ID $session_id may still be creating"
+        return "creating"
+    end
     session_status = response["sessions"][session_id]["status"]
     resource_id = response["sessions"][session_id]["resource_id"]
     if haskey(sessions, session_id)

--- a/Banyan/src/sessions.jl
+++ b/Banyan/src/sessions.jl
@@ -330,7 +330,7 @@ function get_session_status(session_id::String=get_session_id(); kwargs...)
     filters = Dict("session_id" => session_id)
     response = send_request_get_response(:describe_sessions, Dict{String,Any}("filters"=>filters))
     if !haskey(response["sessions"], session_id)
-        @warn "Session with ID $session_id may still be creating"
+        @warn "Session with ID $session_id is assumed to still be creating"
         return "creating"
     end
     session_status = response["sessions"][session_id]["status"]

--- a/Banyan/src/tasks.jl
+++ b/Banyan/src/tasks.jl
@@ -4,23 +4,23 @@
 
 mutable struct DelayedTask
     # Fields for use in processed task ready to be recorded
-    used_modules#::Vector
-    code#::String
-    value_names#::Vector{Tuple{ValueId,String}}
-    effects#::Dict{ValueId,String}
-    pa_union#::Vector{PartitionAnnotation} # Enumeration of applicable PAs
-    memory_usage#::Dict{ValueId,Dict{String,Integer}} # initial/additional/final
+    used_modules::Vector
+    code::String
+    value_names::Vector{Tuple{ValueId,String}}
+    effects::Dict{ValueId,String}
+    pa_union::Vector{PartitionAnnotation} # Enumeration of applicable PAs
+    memory_usage::Dict{ValueId,Dict{String,Integer}} # initial/additional/final
     # Fields for use in task yet to be processed in a call to `compute`
-    partitioned_using_func#::Union{Function,Nothing}
-    partitioned_with_func#::Union{Function,Nothing}
-    mutation#::Dict{Future,Future} # This gets converted to `effects`
+    partitioned_using_func::Union{Function,Nothing}
+    partitioned_with_func::Union{Function,Nothing}
+    mutation::Dict{Future,Future} # This gets converted to `effects`
     # Fields for estimating memory usage
-    inputs#::Vector{Future}
-    outputs#::Vector{Future}
-    scaled#::Vector{Future}
-    keep_same_sample_rate#::Bool
-    memory_usage_constraints#::Vector{PartitioningConstraint}
-    additional_memory_usage_constraints#::Vector{PartitioningConstraint}
+    inputs::Vector{Future}
+    outputs::Vector{Future}
+    scaled::Vector{Future}
+    keep_same_sample_rate::Bool
+    memory_usage_constraints::Vector{PartitioningConstraint}
+    additional_memory_usage_constraints::Vector{PartitioningConstraint}
 end
 
 DelayedTask() = DelayedTask(

--- a/Banyan/src/tasks.jl
+++ b/Banyan/src/tasks.jl
@@ -4,23 +4,23 @@
 
 mutable struct DelayedTask
     # Fields for use in processed task ready to be recorded
-    used_modules::Vector
-    code::String
-    value_names::Vector{Tuple{ValueId,String}}
-    effects::Dict{ValueId,String}
-    pa_union::Vector{PartitionAnnotation} # Enumeration of applicable PAs
-    memory_usage::Dict{ValueId,Dict{String,Integer}} # initial/additional/final
+    used_modules#::Vector
+    code#::String
+    value_names#::Vector{Tuple{ValueId,String}}
+    effects#::Dict{ValueId,String}
+    pa_union#::Vector{PartitionAnnotation} # Enumeration of applicable PAs
+    memory_usage#::Dict{ValueId,Dict{String,Integer}} # initial/additional/final
     # Fields for use in task yet to be processed in a call to `compute`
-    partitioned_using_func::Union{Function,Nothing}
-    partitioned_with_func::Union{Function,Nothing}
-    mutation::Dict{Future,Future} # This gets converted to `effects`
+    partitioned_using_func#::Union{Function,Nothing}
+    partitioned_with_func#::Union{Function,Nothing}
+    mutation#::Dict{Future,Future} # This gets converted to `effects`
     # Fields for estimating memory usage
-    inputs::Vector{Future}
-    outputs::Vector{Future}
-    scaled::Vector{Future}
-    keep_same_sample_rate::Bool
-    memory_usage_constraints::Vector{PartitioningConstraint}
-    additional_memory_usage_constraints::Vector{PartitioningConstraint}
+    inputs#::Vector{Future}
+    outputs#::Vector{Future}
+    scaled#::Vector{Future}
+    keep_same_sample_rate#::Bool
+    memory_usage_constraints#::Vector{PartitioningConstraint}
+    additional_memory_usage_constraints#::Vector{PartitioningConstraint}
 end
 
 DelayedTask() = DelayedTask(

--- a/Banyan/test/offloaded.jl
+++ b/Banyan/test/offloaded.jl
@@ -29,8 +29,6 @@
         @test res4 == 105
         @show get_session().worker_memory_used
 
-
-
         offloaded() do
             x = ones(800000000)
             return 0

--- a/BanyanArrays/src/BanyanArrays.jl
+++ b/BanyanArrays/src/BanyanArrays.jl
@@ -34,7 +34,9 @@ export ReadBlockJuliaArray,
     SplitGroup,
     Rebalance,
     Consolidate,
-    Shuffle
+    Shuffle,
+    collect,
+    getindex
 
 export RemoteTableSource, RemoteTableDestination
 

--- a/BanyanArrays/src/array.jl
+++ b/BanyanArrays/src/array.jl
@@ -376,11 +376,11 @@ function Base.map(f, c::Array{<:Any,N}...; force_parallelism=false) where {T,N}
         partitioned_with(scaled=[c...]) do
             # balanced
             pt(first(c), Blocked(first(c), balanced=true))
-            pt(c[2:end]..., Blocked() & Balanced(), match=first(c), on=["key", "id"])
+            pt(c[2:end]..., Blocked() & Balanced(), match=first(c), on=["key"])
     
             # unbalanced
-            pt(first(c), Blocked(first(c), balanced=false))
-            pt(c[2:end]..., Unbalanced(scaled_by_same_as=first(c)), match=first(c))
+            pt(first(c), Blocked(first(c)))
+            pt(c[2:end]..., ScaledBySame(as=first(c)), match=first(c))
 
             # replicated
             pt(c..., Replicated())
@@ -395,11 +395,13 @@ function Base.map(f, c::Array{<:Any,N}...; force_parallelism=false) where {T,N}
     partitioned_with(scaled=[res, c...]) do
         # balanced
         pt(first(c), Blocked(first(c), balanced=true))
-        pt(c[2:end]..., res, Blocked() & Balanced(), match=first(c), on=["key", "id"])
+        pt(c[2:end]..., Blocked() & Balanced(), match=first(c), on=["key"])
+        pt(res, Blocked() & Balanced(), match=first(c))
 
         # unbalanced
-        pt(first(c), Blocked(first(c), balanced=false, scaled_by_same_as=res))
-        pt(c[2:end]..., res, Unbalanced(scaled_by_same_as=first(c)), match=first(c))
+        pt(first(c), Blocked(first(c)))
+        pt(c[2:end]..., ScaledBySame(as=first(c)), match=first(c))
+        pt(res, ScaledBySame(as=first(c)), match=first(c))
 
         # replicated
         if force_parallelism

--- a/BanyanArrays/src/array.jl
+++ b/BanyanArrays/src/array.jl
@@ -277,7 +277,7 @@ end
 
 fill(v, dims::Integer...) = fill(v, Tuple(dims))
 
-function collect(r::AbstractRange)
+function Base.collect(r::AbstractRange)
     # Create output futures
     r = Future(r)
     A = Future(datatype="Array")
@@ -291,7 +291,7 @@ function collect(r::AbstractRange)
     end
 
     # Offload the partitioned computation
-    @partitioned r A begin A = Base.collect(r) end
+    @partitioned r A begin A = Base.Base.collect(r) end
 
     # Return a Banyan vector as the result
     Vector{eltype(compute(r))}(A, Future((length(compute(r)),)))

--- a/BanyanArrays/src/array.jl
+++ b/BanyanArrays/src/array.jl
@@ -224,7 +224,7 @@ function Banyan.compute_inplace(A::Array{T,N}) where {T,N}
     end
 end
 
-function BanyanArrays.fill(v, dims::NTuple{N,Integer}) where {N}
+function fill(v, dims::NTuple{N,Integer}) where {N}
     fillingdims = Future(source=Size(dims))
     A = Array{typeof(v),N}(Future(datatype="Array"), Future(dims))
     v = Future(v)
@@ -277,7 +277,7 @@ end
 
 fill(v, dims::Integer...) = fill(v, Tuple(dims))
 
-function BanyanArrays.collect(r::AbstractRange)
+function collect(r::AbstractRange)
     # Create output futures
     r = Future(r)
     A = Future(datatype="Array")

--- a/BanyanArrays/src/array.jl
+++ b/BanyanArrays/src/array.jl
@@ -218,7 +218,7 @@ function write_hdf5(A, path; invalidate_source=true, invalidate_sample=true, kwa
     end
 end
 
-function Banyan.write_to_disk(A::Array{T,N}) where {T,N}
+function Banyan.compute_inplace(A::Array{T,N}) where {T,N}
     partitioned_computation(A, destination=Disk()) do
         pt(A, Blocked(A) | Replicated())
     end

--- a/BanyanArrays/src/array.jl
+++ b/BanyanArrays/src/array.jl
@@ -224,7 +224,7 @@ function Banyan.compute_inplace(A::Array{T,N}) where {T,N}
     end
 end
 
-function fill(v, dims::NTuple{N,Integer}) where {N}
+function BanyanArrays.fill(v, dims::NTuple{N,Integer}) where {N}
     fillingdims = Future(source=Size(dims))
     A = Array{typeof(v),N}(Future(datatype="Array"), Future(dims))
     v = Future(v)
@@ -277,7 +277,7 @@ end
 
 fill(v, dims::Integer...) = fill(v, Tuple(dims))
 
-function Base.collect(r::AbstractRange)
+function BanyanArrays.collect(r::AbstractRange)
     # Create output futures
     r = Future(r)
     A = Future(datatype="Array")
@@ -291,7 +291,7 @@ function Base.collect(r::AbstractRange)
     end
 
     # Offload the partitioned computation
-    @partitioned r A begin A = Base.Base.collect(r) end
+    @partitioned r A begin A = Base.collect(r) end
 
     # Return a Banyan vector as the result
     Vector{eltype(compute(r))}(A, Future((length(compute(r)),)))

--- a/BanyanArrays/src/array.jl
+++ b/BanyanArrays/src/array.jl
@@ -546,11 +546,6 @@ function Base.getindex(A::Array{T,N}, indices...) where {T,N}
         if res isa AbstractArray
             res_size = size(res)
         end
-        @show res_size
-        @show typeof(res)
-        @show typeof(res_size)
-        @show typeof(indices)
-        @show indices
     end
 
     if sample(res) isa AbstractArray

--- a/BanyanArrays/src/pfs.jl
+++ b/BanyanArrays/src/pfs.jl
@@ -301,7 +301,7 @@ function CopyToJuliaArray(
         params["key"] = 1
         res = WriteJuliaArray(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
     end
-    if Banyan.get_worker_idx(comm)
+    if get_worker_idx(comm) == 1
         MPI.Barrier(comm)
     end
 end
@@ -756,7 +756,7 @@ function CopyToHDF5(
         params["key"] = 1
         WriteHDF5(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
     end
-    if Banyan.get_worker_idx(comm) == 1
+    if get_worker_idx(comm) == 1
         MPI.Barrier(comm)
     end
 end

--- a/BanyanArrays/src/pfs.jl
+++ b/BanyanArrays/src/pfs.jl
@@ -287,7 +287,7 @@ CopyFromJuliaArray(src, params, batch_idx, nbatches, comm, loc_name, loc_params)
     ReadBlockJuliaArray(src, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
 end
 
-CopyToJuliaArray(
+function CopyToJuliaArray(
     src,
     part,
     params,
@@ -296,9 +296,14 @@ CopyToJuliaArray(
     comm::MPI.Comm,
     loc_name,
     loc_params,
-) = if Banyan.get_partition_idx(batch_idx, nbatches, comm) == 1
-    params["key"] = 1
-    WriteJuliaArray(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
+)
+    if Banyan.get_partition_idx(batch_idx, nbatches, comm) == 1
+        params["key"] = 1
+        res = WriteJuliaArray(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
+    end
+    if Banyan.get_worker_idx(comm)
+        MPI.Barrier(comm)
+    end
 end
 
 function ReadBlockHDF5(
@@ -737,7 +742,7 @@ CopyFromHDF5(src, params, batch_idx, nbatches, comm, loc_name, loc_params) = beg
     ReadBlockHDF5(src, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
 end
 
-CopyToHDF5(
+function CopyToHDF5(
     src,
     part,
     params,
@@ -746,9 +751,14 @@ CopyToHDF5(
     comm::MPI.Comm,
     loc_name,
     loc_params,
-) = if Banyan.get_partition_idx(batch_idx, nbatches, comm) == 1
-    params["key"] = 1
-    WriteHDF5(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
+)
+    if Banyan.get_partition_idx(batch_idx, nbatches, comm) == 1
+        params["key"] = 1
+        WriteHDF5(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
+    end
+    if Banyan.get_worker_idx(comm) == 1
+        MPI.Barrier(comm)
+    end
 end
 
 function Banyan.SplitBlock(

--- a/BanyanArrays/src/pfs.jl
+++ b/BanyanArrays/src/pfs.jl
@@ -301,7 +301,7 @@ function CopyToJuliaArray(
         params["key"] = 1
         res = WriteJuliaArray(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
     end
-    if get_worker_idx(comm) == 1
+    if batch_idx == 1
         MPI.Barrier(comm)
     end
 end
@@ -756,7 +756,7 @@ function CopyToHDF5(
         params["key"] = 1
         WriteHDF5(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
     end
-    if get_worker_idx(comm) == 1
+    if batch_idx == 1
         MPI.Barrier(comm)
     end
 end

--- a/BanyanArrays/test/black_scholes.jl
+++ b/BanyanArrays/test/black_scholes.jl
@@ -40,7 +40,7 @@ using Distributions
         res = compute(call_sum)
         # println(res)
         @show res
-        #res = collect(res)
+        #res = Base.collect(res)
         #end = now()
         #@test typeof(res) == Base.Vector{Float64}
         #@test all(v->v==3.999999985812889, res)

--- a/BanyanArrays/test/hdf5.jl
+++ b/BanyanArrays/test/hdf5.jl
@@ -60,7 +60,7 @@ end
         # Perform computation
 
         x = read_hdf5(joinpath(path, "DS1"))
-        # @show collect(length(x))
+        # @show Base.collect(length(x))
         x = map(e -> e * 10, x)
 
         steps = if startswith(path, "s3://")
@@ -150,9 +150,9 @@ end
         #             @test x_length_collect == 400
         #             x_size_collect = size(x)
         #             @test x_size_collect == (400,)
-        #             x_minimum_collect = collect(minimum(x))
+        #             x_minimum_collect = Base.collect(minimum(x))
         #             @test x_minimum_collect == "Parting"
-        #             x_maximum_collect = collect(maximum(x))
+        #             x_maximum_collect = Base.collect(maximum(x))
         #             @test x_maximum_collect == "sweet"
         #             x_length_collect = length(x)
         #             @test x_length_collect == 400

--- a/BanyanArrays/test/mapreduce.jl
+++ b/BanyanArrays/test/mapreduce.jl
@@ -260,6 +260,7 @@ end
 
         x = BanyanArrays.fill(1.0, (1000, 100))
         x_vecs = mapslices(v -> [v], x, dims=2)[:, 1]
+        bc = BanyanArrays.collect(1:1000)
         res = map(x_vecs, BanyanArrays.collect(1:1000)) do x_vec, i
             length(x_vec) + i
         end

--- a/BanyanArrays/test/mapreduce.jl
+++ b/BanyanArrays/test/mapreduce.jl
@@ -310,6 +310,17 @@ end
     end
 end
 
+# @testset "Main worker stuck" begin
+#     use_session_for_testing(scheduling_config_name = "default scheduling") do
+#         offloaded(distributed=true) do
+#             if get_worker_idx() > 1
+#                 error("Failure right here")
+#             end
+#             sync_across()
+#         end
+#     end
+# end
+
 # TODO: Re-enable this test once we ensure that we can write out small
 # enough datasets without unnecessary batching
 # @testset "String arrays with $scheduling_config" for scheduling_config in [

--- a/BanyanArrays/test/mapreduce.jl
+++ b/BanyanArrays/test/mapreduce.jl
@@ -310,16 +310,16 @@ end
     end
 end
 
-# @testset "Main worker stuck" begin
-#     use_session_for_testing(scheduling_config_name = "default scheduling") do
-#         offloaded(distributed=true) do
-#             if get_worker_idx() > 1
-#                 error("Failure right here")
-#             end
-#             sync_across()
-#         end
-#     end
-# end
+@testset "Main worker stuck" begin
+    use_session_for_testing(scheduling_config_name = "default scheduling") do
+        offloaded(distributed=true) do
+            if get_worker_idx() > 1
+                error("Failure right here")
+            end
+            sync_across()
+        end
+    end
+end
 
 # TODO: Re-enable this test once we ensure that we can write out small
 # enough datasets without unnecessary batching

--- a/BanyanArrays/test/mapreduce.jl
+++ b/BanyanArrays/test/mapreduce.jl
@@ -71,7 +71,7 @@ end
             compute_inplace(x)
             # compute_inplace(x)
             sleep(15)
-            # NOTE: The only reason why we're not putting `collect(x)` inside the
+            # NOTE: The only reason why we're not putting `Base.collect(x)` inside the
             # the `@test` is because `@test` will catch exceptions and prevent the
             # session from getting destroyed when an exception occurs and we can't keep
             # running this test if the session ends
@@ -93,7 +93,7 @@ end
         x = map(e -> e / 10, x)
         compute_inplace(x)
         compute_inplace(x)
-        # NOTE: The only reason why we're not putting `collect(x)` inside the
+        # NOTE: The only reason why we're not putting `Base.collect(x)` inside the
         # the `@test` is because `@test` will catch exceptions and prevent the
         # session from getting destroyed when an exception occurs and we can't keep
         # running this test if the session ends
@@ -334,18 +334,18 @@ end
 #     res = map(*, x1, x2, x3)
 #     res_lengths = map(s -> length(s), res)
 
-#     res_lengths_minimum_collect = collect(minimum(res_lengths))
+#     res_lengths_minimum_collect = Base.collect(minimum(res_lengths))
 #     @test res_lengths_minimum_collect == 18
 
 #     # TODO: Support writing string arrays for this to work
 #     # This is unnecessary but will cache `res` on disk
 #     # compute_inplace(res)
-#     # res_collect = collect(res)
+#     # res_collect = Base.collect(res)
 #     # @test res_collect == BanyanArrays.fill("hello\nhello\nworld\n", 2048)
 
 #     # TODO: Test this once we implement a merging function for
 #     # variable-sized reductions
-#     # res_minimum_collect = collect(minimum(res))
+#     # res_minimum_collect = Base.collect(minimum(res))
 #     # @test res_minimum_collect == "hello\nhello\nworld\n"
 
 #     # TODO: Test this once we implement a merging function for
@@ -353,7 +353,7 @@ end
 #     # x = BanyanArrays.fill("hi\n", 8)
 #     # res = reduce(*, x)
 
-#     # res_collect = collect(res)
+#     # res_collect = Base.collect(res)
 #     # @test res_collect == "hi\nhi\nhi\nhi\nhi\nhi\nhi\nhi\n"
 # end
 

--- a/BanyanArrays/test/mapreduce.jl
+++ b/BanyanArrays/test/mapreduce.jl
@@ -251,6 +251,23 @@ end
     end
 end
 
+@testset "getindex and collect with $scheduling_config" for scheduling_config in [
+    "default scheduling",
+    "parallelism encouraged",
+    "parallelism and batches encouraged",
+]
+    use_session_for_testing(scheduling_config_name = scheduling_config) do
+
+        x = BanyanArrays.fill(1.0, (1000, 100))
+        x_vecs = mapslices(v -> [v], x, dims=2)[:, 1]
+        res = map(x_vecs, BanyanArrays.collect(1:1000)) do x_vec, i
+            length(x_vec) + i
+        end
+        res_sum_compute = compute(sum(res))
+        @test res_sum_compute == sum((1.0 * 100 + i for i in 1:1000))
+    end
+end
+
 # TODO: Re-enable this test once we ensure that we can write out small
 # enough datasets without unnecessary batching
 # @testset "String arrays with $scheduling_config" for scheduling_config in [

--- a/BanyanArrays/test/scholes.jl
+++ b/BanyanArrays/test/scholes.jl
@@ -46,7 +46,7 @@ using Distributions
 
 	call_sum = sum(call)
 	res = compute(call_sum)
-        #res = collect(res)
+        #res = Base.collect(res)
 	#end = now()
         #@test typeof(res) == Base.Vector{Float64}
         #@test all(v->v==3.999999985812889, res)

--- a/BanyanArrays/test/test_black_scholes.jl
+++ b/BanyanArrays/test/test_black_scholes.jl
@@ -42,7 +42,7 @@
 #         res = compute(call_sum)
 # 	    # println(res)
 #         @show res
-#         #res = collect(res)
+#         #res = Base.collect(res)
 #         #end = now()
 #         #@test typeof(res) == Base.Vector{Float64}
 #         #@test all(v->v==3.999999985812889, res)

--- a/BanyanArrays/test/test_hdf5.jl
+++ b/BanyanArrays/test/test_hdf5.jl
@@ -137,9 +137,9 @@ using HDF5
         #             @test x_length_collect == 400
         #             x_size_collect = size(x)
         #             @test x_size_collect == (400,)
-        #             x_minimum_collect = collect(minimum(x))
+        #             x_minimum_collect = Base.collect(minimum(x))
         #             @test x_minimum_collect == "Parting"
-        #             x_maximum_collect = collect(maximum(x))
+        #             x_maximum_collect = Base.collect(maximum(x))
         #             @test x_maximum_collect == "sweet"
         #             x_length_collect = length(x)
         #             @test x_length_collect == 400

--- a/BanyanArrays/test/test_mapreduce.jl
+++ b/BanyanArrays/test/test_mapreduce.jl
@@ -43,7 +43,7 @@
             compute_inplace(x)
             # compute_inplace(x)
             sleep(15)
-            # NOTE: The only reason why we're not putting `collect(x)` inside the
+            # NOTE: The only reason why we're not putting `Base.collect(x)` inside the
             # the `@test` is because `@test` will catch exceptions and prevent the
             # session from getting destroyed when an exception occurs and we can't keep
             # running this test if the session ends
@@ -58,7 +58,7 @@
         x = map(e -> e / 10, x)
         compute_inplace(x)
         compute_inplace(x)
-        # NOTE: The only reason why we're not putting `collect(x)` inside the
+        # NOTE: The only reason why we're not putting `Base.collect(x)` inside the
         # the `@test` is because `@test` will catch exceptions and prevent the
         # session from getting destroyed when an exception occurs and we can't keep
         # running this test if the session ends
@@ -150,18 +150,18 @@
     #     res = map(*, x1, x2, x3)
     #     res_lengths = map(s -> length(s), res)
 
-    #     res_lengths_minimum_collect = collect(minimum(res_lengths))
+    #     res_lengths_minimum_collect = Base.collect(minimum(res_lengths))
     #     @test res_lengths_minimum_collect == 18
 
     #     # TODO: Support writing string arrays for this to work
     #     # This is unnecessary but will cache `res` on disk
     #     # compute_inplace(res)
-    #     # res_collect = collect(res)
+    #     # res_collect = Base.collect(res)
     #     # @test res_collect == BanyanArrays.fill("hello\nhello\nworld\n", 2048)
 
     #     # TODO: Test this once we implement a merging function for
     #     # variable-sized reductions
-    #     # res_minimum_collect = collect(minimum(res))
+    #     # res_minimum_collect = Base.collect(minimum(res))
     #     # @test res_minimum_collect == "hello\nhello\nworld\n"
 
     #     # TODO: Test this once we implement a merging function for
@@ -169,7 +169,7 @@
     #     # x = BanyanArrays.fill("hi\n", 8)
     #     # res = reduce(*, x)
 
-    #     # res_collect = collect(res)
+    #     # res_collect = Base.collect(res)
     #     # @test res_collect == "hi\nhi\nhi\nhi\nhi\nhi\nhi\nhi\n"
     # end
 

--- a/BanyanArrays/test/test_mapreduce.jl
+++ b/BanyanArrays/test/test_mapreduce.jl
@@ -40,8 +40,8 @@
             # NOTE: This also tests simple writing to and reading from local disk
             x = BanyanArrays.fill(10.0, 2048)
             # x = map(e -> e / 10, x)
-            write_to_disk(x)
-            # write_to_disk(x)
+            compute_inplace(x)
+            # compute_inplace(x)
             sleep(15)
             # NOTE: The only reason why we're not putting `collect(x)` inside the
             # the `@test` is because `@test` will catch exceptions and prevent the
@@ -56,15 +56,15 @@
         # NOTE: This also tests simple writing to and reading from local disk
         x = BanyanArrays.fill(10.0, 2048)
         x = map(e -> e / 10, x)
-        write_to_disk(x)
-        write_to_disk(x)
+        compute_inplace(x)
+        compute_inplace(x)
         # NOTE: The only reason why we're not putting `collect(x)` inside the
         # the `@test` is because `@test` will catch exceptions and prevent the
         # session from getting destroyed when an exception occurs and we can't keep
         # running this test if the session ends
         x_collect = compute(x)
         @test x_collect == Base.fill(1.0, 2048)
-        write_to_disk(x)
+        compute_inplace(x)
         x_collect = compute(x)
         @test x_collect == Base.fill(1.0, 2048)
         x_collect = compute(x)
@@ -75,11 +75,11 @@
         x = BanyanArrays.fill(10.0, 2048)
         x_sum = reduce(+, x)
         x = map(e -> e / 10, x)
-        write_to_disk(x)
-        write_to_disk(x_sum)
+        compute_inplace(x)
+        compute_inplace(x_sum)
         x_sum_collect = compute(x_sum)
         @test x_sum_collect == 10.0 * 2048
-        write_to_disk(x_sum)
+        compute_inplace(x_sum)
         x_collect = compute(x)
         @test x_collect == Base.fill(1.0, 2048)
         compute(x_sum)
@@ -155,7 +155,7 @@
 
     #     # TODO: Support writing string arrays for this to work
     #     # This is unnecessary but will cache `res` on disk
-    #     # write_to_disk(res)
+    #     # compute_inplace(res)
     #     # res_collect = collect(res)
     #     # @test res_collect == BanyanArrays.fill("hello\nhello\nworld\n", 2048)
 

--- a/BanyanDataFrames/src/df.jl
+++ b/BanyanDataFrames/src/df.jl
@@ -85,7 +85,7 @@ end
 write_parquet(A, p; kwargs...) = write_csv(A, p; kwargs...)
 write_arrow(A, p; kwargs...) = write_csv(A, p; kwargs...)
 
-function Banyan.write_to_disk(df::DataFrame)
+function Banyan.compute_inplace(df::DataFrame)
     partitioned_computation(df, destination=Disk()) do
         pt(df, Partitioned(df))
     end

--- a/BanyanDataFrames/src/gdf.jl
+++ b/BanyanDataFrames/src/gdf.jl
@@ -144,16 +144,16 @@ function DataFrames.select(gdf::GroupedDataFrame, args...; kwargs...)
     # # TODO: Share sampled names if performance is impacted by repeatedly getting names
 
     # # allowedgroupingkeys = names(sample(gdf_parent), compute(groupcols))
-    # # allowedgroupingkeys = get(collect(groupkwargs), :sort, false) ? allowedgroupingkeys[1:1] : allowedgroupingkeys
+    # # allowedgroupingkeys = get(Base.collect(groupkwargs), :sort, false) ? allowedgroupingkeys[1:1] : allowedgroupingkeys
     # # union!(sample(gdf_parent, :allowedgroupingkeys), allowedgroupingkeys)
-    # if get(collect(kwargs), :keepkeys, true)
+    # if get(Base.collect(kwargs), :keepkeys, true)
     #     union!(sample(res, :allowedgroupingkeys), sample(gdf, :allowedgroupingkeys))
     # end
     # for key in sample(gdf_parent, :allowedgroupingkeys)
     #     setsample(res, :keystatistics, key, sample(gdf_parent, :keystatistics, key))
     #     for balanced in [true, false]
     #         partition(gdf_parent, Grouped(;key=key, balanced=balanced))
-    #         if get(collect(kwargs), :keepkeys, true)
+    #         if get(Base.collect(kwargs), :keepkeys, true)
     #             partition(res, Partitioned(), match=gdf_parent)
     #         else
     #             partition(res, Blocked(dim=1), match=gdf_parent, on=["balanced", "id"])
@@ -315,14 +315,14 @@ end
 #     partition(gdf_parent, Replicated())
 #     partition(res, Replicated())
     
-#     if get(collect(kwargs), :keepkeys, true)
+#     if get(Base.collect(kwargs), :keepkeys, true)
 #         union!(sample(res, :allowedgroupingkeys), sample(gdf, :allowedgroupingkeys))
 #     end
 #     for key in sample(gdf_parent, :allowedgroupingkeys)
 #         setsample(res, :keystatistics, key, sample(gdf_parent, :keystatistics, key))
 #         for balanced in [true, false]
 #             partition(gdf_parent, Grouped(;key=key, balanced=balanced))
-#             if get(collect(kwargs), :keepkeys, true)
+#             if get(Base.collect(kwargs), :keepkeys, true)
 #                 partition(res, Partitioned(), match=gdf_parent)
 #             else
 #                 partition(res, Blocked(dim=1), match=gdf_parent, on=["balanced", "id"])
@@ -363,13 +363,13 @@ end
 #     partition(gdf_parent, Replicated())
 #     partition(res, Replicated())
     
-#     if get(collect(kwargs), :keepkeys, true)
+#     if get(Base.collect(kwargs), :keepkeys, true)
 #         union!(sample(res, :allowedgroupingkeys), sample(gdf, :allowedgroupingkeys))
 #     end
 #     for key in sample(gdf_parent, :allowedgroupingkeys)
 #         for balanced in [true, false]
 #             partition(gdf_parent, Grouped(;key=key, balanced=balanced))
-#             if get(collect(kwargs), :keepkeys, true)
+#             if get(Base.collect(kwargs), :keepkeys, true)
 #                 partition(res, Grouped(key=key, balanced=false, id="*"), match=gdf_parent, on="divisions")
 #             else
 #                 partition(res, Blocked(dim=1, balanced=false, id="*"))
@@ -415,13 +415,13 @@ end
 #     partition(gdf_parent, Replicated())
 #     partition(res, Replicated())
     
-#     if get(collect(kwargs), :keepkeys, true)
+#     if get(Base.collect(kwargs), :keepkeys, true)
 #         union!(sample(res, :allowedgroupingkeys), sample(gdf, :allowedgroupingkeys))
 #     end
 #     for key in sample(gdf_parent, :allowedgroupingkeys)
 #         for balanced in [true, false]
 #             partition(gdf_parent, Grouped(;key=key, balanced=balanced))
-#             if get(collect(kwargs), :keepkeys, true)
+#             if get(Base.collect(kwargs), :keepkeys, true)
 #                 partition(res, Grouped(key=key, balanced=false, id="*"), match=gdf_parent, on="divisions")
 #             else
 #                 partition(res, Blocked(dim=1, balanced=false, id="*"))

--- a/BanyanDataFrames/src/pfs.jl
+++ b/BanyanDataFrames/src/pfs.jl
@@ -621,7 +621,7 @@ function Banyan.Consolidate(part::AbstractDataFrame, src_params::Dict{String,Any
         ) |> IOBuffer |> Arrow.Table |> DataFrames.DataFrame
         for i in 1:Banyan.get_nworkers(comm)
     ]
-    if investigating()[:losing_data]
+    if isinvestigating()[:losing_data]
         @show length(results)
         @show nrow.(results)
     end

--- a/BanyanDataFrames/src/pfs.jl
+++ b/BanyanDataFrames/src/pfs.jl
@@ -676,12 +676,15 @@ function Banyan.Shuffle(
     )
     println("In Shuffle after get_partition_idx_from_divisions")
     res = begin
+        println("In Shuffle before transform with typeof(part)=$(typeof(part)) and isempty(part)=$(isempty(part))")
         gdf = if !isempty(part)
             # Compute the partition to send each row of the dataframe to
             DataFrames.transform!(part, key => ByRow(partition_idx_getter) => :banyan_shuffling_key)
+            println("In Shuffle after transform! with typeof(part)=$(typeof(part)) and isempty(part)=$(isempty(part))")
 
             # Group the dataframe's rows by what partition to send to
             gdf = DataFrames.groupby(part, :banyan_shuffling_key, sort = true)
+            println("In Shuffle after groupby with typeof(part)=$(typeof(part)) and isempty(part)=$(isempty(part))")
             gdf
         else
             nothing

--- a/BanyanDataFrames/src/pfs.jl
+++ b/BanyanDataFrames/src/pfs.jl
@@ -190,6 +190,7 @@ ReadBlockCSV, ReadBlockParquet, ReadBlockArrow = [
             else
                 vcat(dfs...)
             end
+            println("Finished ReadBlock")
             res
         end
         ReadBlock

--- a/BanyanDataFrames/src/pfs.jl
+++ b/BanyanDataFrames/src/pfs.jl
@@ -77,7 +77,7 @@ ReadBlockCSV, ReadBlockParquet, ReadBlockArrow = [
 
             path = Banyan.getpath(loc_params["path"], comm)
 
-            if isinvestigating()[:losing_data]
+            if isinvestigating()[:losing_data] || true
                 println("In ReadBlock with path=$path, loc_params=$params")
             end
 
@@ -147,10 +147,11 @@ ReadBlockCSV, ReadBlockParquet, ReadBlockArrow = [
                     # TODO: Scale the memory usage appropriately when splitting with
                     # this and garbage collect if too much memory is used.
                     if endswith(file_path, file_extension)
-                        if isinvestigating()[:losing_data]
+                        if isinvestigating()[:losing_data] || true
                             println("In ReadBlock calling read_file with path=$path, filerowrange=$filerowrange, readrange=$readrange, rowrange=$rowrange")
                         end
                         read_file(path, header, rowrange, readrange, filerowrange, dfs)
+                        println("Successfully read file")
                     else
                         error("Expected file with $file_extension extension")
                     end

--- a/BanyanDataFrames/src/pfs.jl
+++ b/BanyanDataFrames/src/pfs.jl
@@ -354,7 +354,7 @@ CopyFromParquet(src, params, batch_idx, nbatches, comm, loc_name, loc_params) = 
     ReadBlockParquet(src, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
 end
 
-CopyToCSV(
+function CopyToCSV(
     src,
     part,
     params,
@@ -363,12 +363,17 @@ CopyToCSV(
     comm::MPI.Comm,
     loc_name,
     loc_params,
-) = if Banyan.get_partition_idx(batch_idx, nbatches, comm) == 1
-    params["key"] = 1
-    WriteCSV(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
+)
+    if Banyan.get_partition_idx(batch_idx, nbatches, comm) == 1
+        params["key"] = 1
+        WriteCSV(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
+    end
+    if get_worker_idx(comm) == 1
+        MPI.Barrier(comm)
+    end
 end
 
-CopyToParquet(
+function CopyToParquet(
     src,
     part,
     params,
@@ -377,12 +382,17 @@ CopyToParquet(
     comm::MPI.Comm,
     loc_name,
     loc_params,
-) = if Banyan.get_partition_idx(batch_idx, nbatches, comm) == 1
-    params["key"] = 1
-    WriteParquet(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
+)
+    if Banyan.get_partition_idx(batch_idx, nbatches, comm) == 1
+        params["key"] = 1
+        WriteParquet(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
+    end
+    if get_worker_idx(comm) == 1
+        MPI.Barrier(comm)
+    end
 end
 
-CopyToArrow(
+function CopyToArrow(
     src,
     part,
     params,
@@ -391,9 +401,14 @@ CopyToArrow(
     comm::MPI.Comm,
     loc_name,
     loc_params,
-) = if Banyan.get_partition_idx(batch_idx, nbatches, comm) == 1
-    params["key"] = 1
-    WriteArrow(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
+)
+    if Banyan.get_partition_idx(batch_idx, nbatches, comm) == 1
+        params["key"] = 1
+        WriteArrow(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
+    end
+    if get_worker_idx(comm) == 1
+        MPI.Barrier(comm)
+    end
 end
 
 function Banyan.SplitBlock(

--- a/BanyanDataFrames/src/pfs.jl
+++ b/BanyanDataFrames/src/pfs.jl
@@ -368,7 +368,7 @@ function CopyToCSV(
         params["key"] = 1
         WriteCSV(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
     end
-    if get_worker_idx(comm) == 1
+    if batch_idx == 1
         MPI.Barrier(comm)
     end
 end
@@ -387,7 +387,7 @@ function CopyToParquet(
         params["key"] = 1
         WriteParquet(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
     end
-    if get_worker_idx(comm) == 1
+    if batch_idx == 1
         MPI.Barrier(comm)
     end
 end
@@ -406,7 +406,7 @@ function CopyToArrow(
         params["key"] = 1
         WriteArrow(src, part, params, 1, 1, MPI.COMM_SELF, loc_name, loc_params)
     end
-    if get_worker_idx(comm) == 1
+    if batch_idx == 1
         MPI.Barrier(comm)
     end
 end

--- a/BanyanDataFrames/src/pfs.jl
+++ b/BanyanDataFrames/src/pfs.jl
@@ -680,9 +680,11 @@ function Banyan.Shuffle(
         gdf = if !isempty(part)
             # Compute the partition to send each row of the dataframe to
             DataFrames.transform!(part, key => ByRow(partition_idx_getter) => :banyan_shuffling_key)
+            DataFrames.transform(part, key => ByRow(partition_idx_getter) => :banyan_shuffling_key)
             println("In Shuffle after transform! with typeof(part)=$(typeof(part)) and isempty(part)=$(isempty(part))")
 
             # Group the dataframe's rows by what partition to send to
+            @show part
             gdf = DataFrames.groupby(part, :banyan_shuffling_key, sort = true)
             println("In Shuffle after groupby with typeof(part)=$(typeof(part)) and isempty(part)=$(isempty(part))")
             gdf

--- a/BanyanDataFrames/src/pfs.jl
+++ b/BanyanDataFrames/src/pfs.jl
@@ -685,6 +685,11 @@ function Banyan.Shuffle(
 
             # Group the dataframe's rows by what partition to send to
             @show part
+            @show @isdefined DataFrames.groupby
+            gdf = DataFrames.groupby(part, :species)
+            println("In Shuffle after groupby with typeof(part)=$(typeof(part)) and isempty(part)=$(isempty(part)) with :species")
+            gdf = DataFrames.groupby(part, :banyan_shuffling_key)
+            println("In Shuffle after groupby with typeof(part)=$(typeof(part)) and isempty(part)=$(isempty(part)) without sort=true")
             gdf = DataFrames.groupby(part, :banyan_shuffling_key, sort = true)
             println("In Shuffle after groupby with typeof(part)=$(typeof(part)) and isempty(part)=$(isempty(part))")
             gdf

--- a/BanyanDataFrames/src/pfs.jl
+++ b/BanyanDataFrames/src/pfs.jl
@@ -685,7 +685,7 @@ function Banyan.Shuffle(
 
             # Group the dataframe's rows by what partition to send to
             @show part
-            @show @isdefined DataFrames.groupby
+            # @show @isdefined DataFrames.groupby
             gdf = DataFrames.groupby(part, :species)
             println("In Shuffle after groupby with typeof(part)=$(typeof(part)) and isempty(part)=$(isempty(part)) with :species")
             gdf = DataFrames.groupby(part, :banyan_shuffling_key)

--- a/BanyanDataFrames/test/groupby_filter_indexing.jl
+++ b/BanyanDataFrames/test/groupby_filter_indexing.jl
@@ -535,8 +535,8 @@ end
             # Test size after filtering single-row dataset
             if isinvestigating()[:size_exaggurated_tests]
                 CSV.write("test_res_filtered_single.csv", sample(filtered_single))
-                filtered_single_sub = subset(groupby(filtered_single, :species), :petal_length => pl -> pl .>= mean(pl))
             end
+            filtered_single_sub = subset(groupby(filtered_single, :species), :petal_length => pl -> pl .>= mean(pl))
             filtered_single_sub_size = size(filtered_single_sub)
             @test filtered_single_sub_size == (1, 5)
             

--- a/BanyanDataFrames/test/groupby_filter_indexing.jl
+++ b/BanyanDataFrames/test/groupby_filter_indexing.jl
@@ -70,8 +70,8 @@
                 # Collect results
                 sub3_nrow = nrow(sub3)
                 sub3 = sort(compute(sub3))
-                sub3_row8 = collect(sub3[8, :])
-                sub3_row62 = collect(sub3[62, :])
+                sub3_row8 = Base.collect(sub3[8, :])
+                sub3_row62 = Base.collect(sub3[62, :])
 
                 # Assert
                 @test sub3_nrow == 62
@@ -103,8 +103,8 @@
                     ),
                 )
                 sub4 = sort(compute(sub4))
-                sub4_row8 = collect(sub4[8, :])
-                sub4_row114 = collect(sub4[114, :])
+                sub4_row8 = Base.collect(sub4[8, :])
+                sub4_row114 = Base.collect(sub4[114, :])
 
                 # Assert
                 @test sub4_nrow == 114
@@ -131,8 +131,8 @@
                 # Collect results
                 sub5_nrow = nrow(sub5)
                 sub5 = sort(compute(sub5))
-                sub5_row1 = collect(sub5[1, :])
-                sub5_row18 = collect(sub5[18, :])
+                sub5_row1 = Base.collect(sub5[1, :])
+                sub5_row18 = Base.collect(sub5[18, :])
 
                 # Assert
                 @test sub5_nrow == 18
@@ -176,7 +176,7 @@ end
                 sub_nrow = nrow(sub)
                 sub_tripdistance_sum = round(compute(reduce(+, sub[:, :trip_distance])))
                 sub_valid = round(compute(reduce(&, map(d -> d > 1.0, sub[:, :trip_distance]))))
-                #sub_hour_sum = collect(
+                #sub_hour_sum = Base.collect(
                 #    reduce(
                 #        +,
                 #        map(
@@ -290,7 +290,7 @@ end
                 gdf_subset_nrow = nrow(gdf_subset)
                 @test gdf_subset_nrow == 474
                 gdf_subset_collected = sort(compute(gdf_subset))
-                gdf_subset_row474 = collect(gdf_subset_collected[474, :])
+                gdf_subset_row474 = Base.collect(gdf_subset_collected[474, :])
                 gdf_select_plf_square_add = round(
                     compute(reduce(+, map(l -> l * l, gdf_select[:, :petal_length_function]))),
                     digits = 2,
@@ -306,9 +306,9 @@ end
                 gdf_transform_length =
                     length(groupby(gdf_transform, [:species, :species_function]))
                 gdf_subset_collected = sort(compute(gdf_subset))
-                gdf_subset_row5 = collect(gdf_subset_collected[5, :])
-                gdf_subset_row333 = collect(gdf_subset_collected[333, :])
-                gdf_subset_row474 = collect(gdf_subset_collected[474, :])
+                gdf_subset_row5 = Base.collect(gdf_subset_collected[5, :])
+                gdf_subset_row333 = Base.collect(gdf_subset_collected[333, :])
+                gdf_subset_row474 = Base.collect(gdf_subset_collected[474, :])
                 # gdf_keepkeys_false_names = names(combine(gdf, nrow, keepkeys = false))
                 gdf_keepkeys_true_names = Set(names(combine(gdf, nrow, keepkeys = true)))
                 petal_length_mean =
@@ -617,7 +617,7 @@ end
 
         @test size(df1) == (1, 5)
         @test names(df1) == ["sepal_length", "sepal_width", "petal_length", "petal_width", "species"]
-        @test collect(df1[1, :]) == [4.9, 3.0, 1.4, 0.2, "setosa"]
+        @test Base.collect(df1[1, :]) == [4.9, 3.0, 1.4, 0.2, "setosa"]
 
         @test size(df2) == (0, 5)
         @test names(df2) == ["sepal_length", "sepal_width", "petal_length", "petal_width", "species"]
@@ -653,7 +653,7 @@ end
         df02 = compute(filt02)
 
         @test size(df01) == (1, 5)
-        @test collect(df01[1, :]) == [4.9, 3.0, 1.4, 0.2, "species_10"]
+        @test Base.collect(df01[1, :]) == [4.9, 3.0, 1.4, 0.2, "species_10"]
 
         @test size(df02) == (0, 5)
         @test names(df02) == ["sepal_length", "sepal_width", "petal_length", "petal_width", "species"]

--- a/BanyanDataFrames/test/groupby_filter_indexing.jl
+++ b/BanyanDataFrames/test/groupby_filter_indexing.jl
@@ -207,11 +207,11 @@ end
 
         bucket = get_cluster_s3_bucket_name()
 
-        for i = 1:2
+        for i = 1:1#2
             for path in [
                 "s3://$(bucket)/iris_large.csv",
-                "s3://$(bucket)/iris_large.parquet",
-                "s3://$(bucket)/iris_large.arrow",
+                # "s3://$(bucket)/iris_large.parquet",
+                # "s3://$(bucket)/iris_large.arrow",
             ]
                 df = read_file(path)
 
@@ -219,164 +219,164 @@ end
                 @test_throws ErrorException groupby(df, :species; sort = false)
 
                 # Groupby all columns
-                gdf = groupby(df, :)
-                @test length(gdf) == 882
+                # gdf = groupby(df, :)
+                # @test length(gdf) == 882
 
-                # Groupby first four columns
-                gdf = groupby(df, Cols(Between(1, 4)))
-                @test length(gdf) == 147
+                # # Groupby first four columns
+                # gdf = groupby(df, Cols(Between(1, 4)))
+                # @test length(gdf) == 147
 
-                # Groupby multiple columns selected using regex
-                gdf = groupby(df, r".*width")
-                @test length(gdf) == 97
+                # # Groupby multiple columns selected using regex
+                # gdf = groupby(df, r".*width")
+                # @test length(gdf) == 97
 
-                gdf_select_save_path = "s3://$(bucket)/test-tmp_gdf_select_$(split(path, "/")[end])"
+                # gdf_select_save_path = "s3://$(bucket)/test-tmp_gdf_select_$(split(path, "/")[end])"
                 gdf_transform_save_path = "s3://$(bucket)/test-tmp_gdf_transform_$(split(path, "/")[end])"
-                gdf_subset_save_path = "s3://$(bucket)/test-tmp_gdf_subset_$(split(path, "/")[end])"
+                # gdf_subset_save_path = "s3://$(bucket)/test-tmp_gdf_subset_$(split(path, "/")[end])"
 
                 gdf = groupby(df, :species)
 
-                # Assert exception gets thrown for parameters that aren't supported
-                @test_throws ArgumentError select(
-                    gdf,
-                    :,
-                    [:petal_length] => (pl) -> pl .- mean(pl);
-                    ungroup = false,
-                )
-                @test_throws ArgumentError select(
-                    gdf,
-                    :,
-                    [:petal_length] => (pl) -> pl .- mean(pl);
-                    copycols = false,
-                )
-                @test_throws ArgumentError transform(
-                    gdf,
-                    :species => x -> "iris-" .* x;
-                    ungroup = false,
-                )
-                @test_throws ArgumentError transform(
-                    gdf,
-                    :species => x -> "iris-" .* x;
-                    copycols = false,
-                )
-                @test_throws ArgumentError subset(
-                    gdf,
-                    :petal_length => pl -> pl .>= mean(pl);
-                    ungroup = false,
-                )
-                @test_throws ArgumentError subset(
-                    gdf,
-                    :petal_length => pl -> pl .>= mean(pl);
-                    copycols = false,
-                )
+                # # Assert exception gets thrown for parameters that aren't supported
+                # @test_throws ArgumentError select(
+                #     gdf,
+                #     :,
+                #     [:petal_length] => (pl) -> pl .- mean(pl);
+                #     ungroup = false,
+                # )
+                # @test_throws ArgumentError select(
+                #     gdf,
+                #     :,
+                #     [:petal_length] => (pl) -> pl .- mean(pl);
+                #     copycols = false,
+                # )
+                # @test_throws ArgumentError transform(
+                #     gdf,
+                #     :species => x -> "iris-" .* x;
+                #     ungroup = false,
+                # )
+                # @test_throws ArgumentError transform(
+                #     gdf,
+                #     :species => x -> "iris-" .* x;
+                #     copycols = false,
+                # )
+                # @test_throws ArgumentError subset(
+                #     gdf,
+                #     :petal_length => pl -> pl .>= mean(pl);
+                #     ungroup = false,
+                # )
+                # @test_throws ArgumentError subset(
+                #     gdf,
+                #     :petal_length => pl -> pl .>= mean(pl);
+                #     copycols = false,
+                # )
 
                 # Groupby species and perform select, transform, subset
                 if i == 1
-                    gdf_select = select(gdf, :, [:petal_length] => (pl) -> pl .- mean(pl))
+                    # gdf_select = select(gdf, :, [:petal_length] => (pl) -> pl .- mean(pl))
                     gdf_transform = transform(gdf, :species => x -> "iris-" .* x)
-                    gdf_subset = subset(gdf, :petal_length => pl -> pl .>= mean(pl))
-                    write_file(gdf_select_save_path, gdf_select)
+                    # gdf_subset = subset(gdf, :petal_length => pl -> pl .>= mean(pl))
+                    # write_file(gdf_select_save_path, gdf_select)
                     write_file(gdf_transform_save_path, gdf_transform)
-                    write_file(gdf_subset_save_path, gdf_subset)
+                    # write_file(gdf_subset_save_path, gdf_subset)
                 else
-                    gdf_select = read_file(gdf_select_save_path)
+                    # gdf_select = read_file(gdf_select_save_path)
                     gdf_transform = read_file(gdf_transform_save_path)
-                    gdf_subset = read_file(gdf_subset_save_path)
+                    # gdf_subset = read_file(gdf_subset_save_path)
                 end
 
                 # Collect results
-                gdf_select_size = size(gdf_select)
+                # gdf_select_size = size(gdf_select)
                 gdf_transform_size = size(gdf_transform)
-                gdf_subset_nrow = nrow(gdf_subset)
-                @test gdf_subset_nrow == 474
-                gdf_subset_collected = sort(compute(gdf_subset))
-                gdf_subset_row474 = Base.collect(gdf_subset_collected[474, :])
-                gdf_select_plf_square_add = round(
-                    compute(reduce(+, map(l -> l * l, gdf_select[:, :petal_length_function]))),
-                    digits = 2,
-                )
-                gdf_select_filter_length = nrow(
-                    compute(
-                        gdf_select[:, [:petal_length]][
-                            map(l -> l .== 1.3, gdf_select[:, :petal_length]),
-                            :,
-                        ],
-                    ),
-                )
+                # gdf_subset_nrow = nrow(gdf_subset)
+                # @test gdf_subset_nrow == 474
+                # gdf_subset_collected = sort(compute(gdf_subset))
+                # gdf_subset_row474 = Base.collect(gdf_subset_collected[474, :])
+                # gdf_select_plf_square_add = round(
+                #     compute(reduce(+, map(l -> l * l, gdf_select[:, :petal_length_function]))),
+                #     digits = 2,
+                # )
+                # gdf_select_filter_length = nrow(
+                #     compute(
+                #         gdf_select[:, [:petal_length]][
+                #             map(l -> l .== 1.3, gdf_select[:, :petal_length]),
+                #             :,
+                #         ],
+                #     ),
+                # )
                 gdf_transform_length =
                     length(groupby(gdf_transform, [:species, :species_function]))
-                gdf_subset_collected = sort(compute(gdf_subset))
-                gdf_subset_row5 = Base.collect(gdf_subset_collected[5, :])
-                gdf_subset_row333 = Base.collect(gdf_subset_collected[333, :])
-                gdf_subset_row474 = Base.collect(gdf_subset_collected[474, :])
-                # gdf_keepkeys_false_names = names(combine(gdf, nrow, keepkeys = false))
-                gdf_keepkeys_true_names = Set(names(combine(gdf, nrow, keepkeys = true)))
-                petal_length_mean =
-                    sort(compute(combine(gdf, :petal_length => mean)), :petal_length_mean)[
-                        :,
-                        :petal_length_mean,
-                    ]
-                petal_length_mean = map(m -> round(m, digits = 2), petal_length_mean)
-                temp = combine(gdf, :petal_length => mean, renamecols = false)
-                temp_names = Set(names(temp))
-                temp_petal_length = sort(compute(temp)[:, :petal_length])
-                temp_petal_length = map(l -> round(l, digits = 2), temp_petal_length)
+                # gdf_subset_collected = sort(compute(gdf_subset))
+                # gdf_subset_row5 = Base.collect(gdf_subset_collected[5, :])
+                # gdf_subset_row333 = Base.collect(gdf_subset_collected[333, :])
+                # gdf_subset_row474 = Base.collect(gdf_subset_collected[474, :])
+                # # gdf_keepkeys_false_names = names(combine(gdf, nrow, keepkeys = false))
+                # gdf_keepkeys_true_names = Set(names(combine(gdf, nrow, keepkeys = true)))
+                # petal_length_mean =
+                #     sort(compute(combine(gdf, :petal_length => mean)), :petal_length_mean)[
+                #         :,
+                #         :petal_length_mean,
+                #     ]
+                # petal_length_mean = map(m -> round(m, digits = 2), petal_length_mean)
+                # temp = combine(gdf, :petal_length => mean, renamecols = false)
+                # temp_names = Set(names(temp))
+                # temp_petal_length = sort(compute(temp)[:, :petal_length])
+                # temp_petal_length = map(l -> round(l, digits = 2), temp_petal_length)
 
-                # Assert
-                @test gdf_select_size == (900, 6)
+                # # Assert
+                # @test gdf_select_size == (900, 6)
                 @test gdf_transform_size == (900, 6)
-                @test gdf_subset_nrow == 474
-                @test gdf_select_plf_square_add == 163.32
-                @test gdf_select_filter_length == 42
+                # @test gdf_subset_nrow == 474
+                # @test gdf_select_plf_square_add == 163.32
+                # @test gdf_select_filter_length == 42
                 @test gdf_transform_length == 18
-                @test gdf_subset_row5 == [4.6, 3.1, 1.5, 0.2, "species_4"]
-                @test gdf_subset_row333 == [6.7, 2.5, 5.8, 1.8, "species_18"]
-                @test gdf_subset_row474 == [7.9, 3.8, 6.4, 2.0, "virginica"]
+                # @test gdf_subset_row5 == [4.6, 3.1, 1.5, 0.2, "species_4"]
+                # @test gdf_subset_row333 == [6.7, 2.5, 5.8, 1.8, "species_18"]
+                # @test gdf_subset_row474 == [7.9, 3.8, 6.4, 2.0, "virginica"]
 
-                # Combine
-                # @test gdf_keepkeys_false_names == ["nrow"]
-                @test gdf_keepkeys_true_names == Set(["nrow", "species"])
-                @test petal_length_mean == [
-                    1.46,
-                    1.46,
-                    1.46,
-                    1.46,
-                    1.46,
-                    1.46,
-                    4.26,
-                    4.26,
-                    4.26,
-                    4.26,
-                    4.26,
-                    4.26,
-                    5.55,
-                    5.55,
-                    5.55,
-                    5.55,
-                    5.55,
-                    5.55,
-                ]
-                @test temp_names == Set(["petal_length", "species"])
-                @test temp_petal_length == [
-                    1.46,
-                    1.46,
-                    1.46,
-                    1.46,
-                    1.46,
-                    1.46,
-                    4.26,
-                    4.26,
-                    4.26,
-                    4.26,
-                    4.26,
-                    4.26,
-                    5.55,
-                    5.55,
-                    5.55,
-                    5.55,
-                    5.55,
-                    5.55,
-                ]
+                # # Combine
+                # # @test gdf_keepkeys_false_names == ["nrow"]
+                # @test gdf_keepkeys_true_names == Set(["nrow", "species"])
+                # @test petal_length_mean == [
+                #     1.46,
+                #     1.46,
+                #     1.46,
+                #     1.46,
+                #     1.46,
+                #     1.46,
+                #     4.26,
+                #     4.26,
+                #     4.26,
+                #     4.26,
+                #     4.26,
+                #     4.26,
+                #     5.55,
+                #     5.55,
+                #     5.55,
+                #     5.55,
+                #     5.55,
+                #     5.55,
+                # ]
+                # @test temp_names == Set(["petal_length", "species"])
+                # @test temp_petal_length == [
+                #     1.46,
+                #     1.46,
+                #     1.46,
+                #     1.46,
+                #     1.46,
+                #     1.46,
+                #     4.26,
+                #     4.26,
+                #     4.26,
+                #     4.26,
+                #     4.26,
+                #     4.26,
+                #     5.55,
+                #     5.55,
+                #     5.55,
+                #     5.55,
+                #     5.55,
+                #     5.55,
+                # ]
             end
         end
     end
@@ -535,8 +535,8 @@ end
             # Test size after filtering single-row dataset
             if isinvestigating()[:size_exaggurated_tests]
                 CSV.write("test_res_filtered_single.csv", sample(filtered_single))
+                filtered_single_sub = subset(groupby(filtered_single, :species), :petal_length => pl -> pl .>= mean(pl))
             end
-            filtered_single_sub = subset(groupby(filtered_single, :species), :petal_length => pl -> pl .>= mean(pl))
             filtered_single_sub_size = size(filtered_single_sub)
             @test filtered_single_sub_size == (1, 5)
             

--- a/BanyanDataFrames/test/groupby_filter_indexing.jl
+++ b/BanyanDataFrames/test/groupby_filter_indexing.jl
@@ -207,11 +207,11 @@ end
 
         bucket = get_cluster_s3_bucket_name()
 
-        for i = 1:1#2
+        for i = 1:2
             for path in [
                 "s3://$(bucket)/iris_large.csv",
-                # "s3://$(bucket)/iris_large.parquet",
-                # "s3://$(bucket)/iris_large.arrow",
+                "s3://$(bucket)/iris_large.parquet",
+                "s3://$(bucket)/iris_large.arrow",
             ]
                 df = read_file(path)
 
@@ -219,164 +219,164 @@ end
                 @test_throws ErrorException groupby(df, :species; sort = false)
 
                 # Groupby all columns
-                # gdf = groupby(df, :)
-                # @test length(gdf) == 882
+                gdf = groupby(df, :)
+                @test length(gdf) == 882
 
-                # # Groupby first four columns
-                # gdf = groupby(df, Cols(Between(1, 4)))
-                # @test length(gdf) == 147
+                # Groupby first four columns
+                gdf = groupby(df, Cols(Between(1, 4)))
+                @test length(gdf) == 147
 
-                # # Groupby multiple columns selected using regex
-                # gdf = groupby(df, r".*width")
-                # @test length(gdf) == 97
+                # Groupby multiple columns selected using regex
+                gdf = groupby(df, r".*width")
+                @test length(gdf) == 97
 
-                # gdf_select_save_path = "s3://$(bucket)/test-tmp_gdf_select_$(split(path, "/")[end])"
+                gdf_select_save_path = "s3://$(bucket)/test-tmp_gdf_select_$(split(path, "/")[end])"
                 gdf_transform_save_path = "s3://$(bucket)/test-tmp_gdf_transform_$(split(path, "/")[end])"
-                # gdf_subset_save_path = "s3://$(bucket)/test-tmp_gdf_subset_$(split(path, "/")[end])"
+                gdf_subset_save_path = "s3://$(bucket)/test-tmp_gdf_subset_$(split(path, "/")[end])"
 
                 gdf = groupby(df, :species)
 
-                # # Assert exception gets thrown for parameters that aren't supported
-                # @test_throws ArgumentError select(
-                #     gdf,
-                #     :,
-                #     [:petal_length] => (pl) -> pl .- mean(pl);
-                #     ungroup = false,
-                # )
-                # @test_throws ArgumentError select(
-                #     gdf,
-                #     :,
-                #     [:petal_length] => (pl) -> pl .- mean(pl);
-                #     copycols = false,
-                # )
-                # @test_throws ArgumentError transform(
-                #     gdf,
-                #     :species => x -> "iris-" .* x;
-                #     ungroup = false,
-                # )
-                # @test_throws ArgumentError transform(
-                #     gdf,
-                #     :species => x -> "iris-" .* x;
-                #     copycols = false,
-                # )
-                # @test_throws ArgumentError subset(
-                #     gdf,
-                #     :petal_length => pl -> pl .>= mean(pl);
-                #     ungroup = false,
-                # )
-                # @test_throws ArgumentError subset(
-                #     gdf,
-                #     :petal_length => pl -> pl .>= mean(pl);
-                #     copycols = false,
-                # )
+                # Assert exception gets thrown for parameters that aren't supported
+                @test_throws ArgumentError select(
+                    gdf,
+                    :,
+                    [:petal_length] => (pl) -> pl .- mean(pl);
+                    ungroup = false,
+                )
+                @test_throws ArgumentError select(
+                    gdf,
+                    :,
+                    [:petal_length] => (pl) -> pl .- mean(pl);
+                    copycols = false,
+                )
+                @test_throws ArgumentError transform(
+                    gdf,
+                    :species => x -> "iris-" .* x;
+                    ungroup = false,
+                )
+                @test_throws ArgumentError transform(
+                    gdf,
+                    :species => x -> "iris-" .* x;
+                    copycols = false,
+                )
+                @test_throws ArgumentError subset(
+                    gdf,
+                    :petal_length => pl -> pl .>= mean(pl);
+                    ungroup = false,
+                )
+                @test_throws ArgumentError subset(
+                    gdf,
+                    :petal_length => pl -> pl .>= mean(pl);
+                    copycols = false,
+                )
 
                 # Groupby species and perform select, transform, subset
                 if i == 1
-                    # gdf_select = select(gdf, :, [:petal_length] => (pl) -> pl .- mean(pl))
+                    gdf_select = select(gdf, :, [:petal_length] => (pl) -> pl .- mean(pl))
                     gdf_transform = transform(gdf, :species => x -> "iris-" .* x)
-                    # gdf_subset = subset(gdf, :petal_length => pl -> pl .>= mean(pl))
-                    # write_file(gdf_select_save_path, gdf_select)
+                    gdf_subset = subset(gdf, :petal_length => pl -> pl .>= mean(pl))
+                    write_file(gdf_select_save_path, gdf_select)
                     write_file(gdf_transform_save_path, gdf_transform)
-                    # write_file(gdf_subset_save_path, gdf_subset)
+                    write_file(gdf_subset_save_path, gdf_subset)
                 else
-                    # gdf_select = read_file(gdf_select_save_path)
+                    gdf_select = read_file(gdf_select_save_path)
                     gdf_transform = read_file(gdf_transform_save_path)
-                    # gdf_subset = read_file(gdf_subset_save_path)
+                    gdf_subset = read_file(gdf_subset_save_path)
                 end
 
                 # Collect results
-                # gdf_select_size = size(gdf_select)
+                gdf_select_size = size(gdf_select)
                 gdf_transform_size = size(gdf_transform)
-                # gdf_subset_nrow = nrow(gdf_subset)
-                # @test gdf_subset_nrow == 474
-                # gdf_subset_collected = sort(compute(gdf_subset))
-                # gdf_subset_row474 = Base.collect(gdf_subset_collected[474, :])
-                # gdf_select_plf_square_add = round(
-                #     compute(reduce(+, map(l -> l * l, gdf_select[:, :petal_length_function]))),
-                #     digits = 2,
-                # )
-                # gdf_select_filter_length = nrow(
-                #     compute(
-                #         gdf_select[:, [:petal_length]][
-                #             map(l -> l .== 1.3, gdf_select[:, :petal_length]),
-                #             :,
-                #         ],
-                #     ),
-                # )
+                gdf_subset_nrow = nrow(gdf_subset)
+                @test gdf_subset_nrow == 474
+                gdf_subset_collected = sort(compute(gdf_subset))
+                gdf_subset_row474 = Base.collect(gdf_subset_collected[474, :])
+                gdf_select_plf_square_add = round(
+                    compute(reduce(+, map(l -> l * l, gdf_select[:, :petal_length_function]))),
+                    digits = 2,
+                )
+                gdf_select_filter_length = nrow(
+                    compute(
+                        gdf_select[:, [:petal_length]][
+                            map(l -> l .== 1.3, gdf_select[:, :petal_length]),
+                            :,
+                        ],
+                    ),
+                )
                 gdf_transform_length =
                     length(groupby(gdf_transform, [:species, :species_function]))
-                # gdf_subset_collected = sort(compute(gdf_subset))
-                # gdf_subset_row5 = Base.collect(gdf_subset_collected[5, :])
-                # gdf_subset_row333 = Base.collect(gdf_subset_collected[333, :])
-                # gdf_subset_row474 = Base.collect(gdf_subset_collected[474, :])
-                # # gdf_keepkeys_false_names = names(combine(gdf, nrow, keepkeys = false))
-                # gdf_keepkeys_true_names = Set(names(combine(gdf, nrow, keepkeys = true)))
-                # petal_length_mean =
-                #     sort(compute(combine(gdf, :petal_length => mean)), :petal_length_mean)[
-                #         :,
-                #         :petal_length_mean,
-                #     ]
-                # petal_length_mean = map(m -> round(m, digits = 2), petal_length_mean)
-                # temp = combine(gdf, :petal_length => mean, renamecols = false)
-                # temp_names = Set(names(temp))
-                # temp_petal_length = sort(compute(temp)[:, :petal_length])
-                # temp_petal_length = map(l -> round(l, digits = 2), temp_petal_length)
+                gdf_subset_collected = sort(compute(gdf_subset))
+                gdf_subset_row5 = Base.collect(gdf_subset_collected[5, :])
+                gdf_subset_row333 = Base.collect(gdf_subset_collected[333, :])
+                gdf_subset_row474 = Base.collect(gdf_subset_collected[474, :])
+                # gdf_keepkeys_false_names = names(combine(gdf, nrow, keepkeys = false))
+                gdf_keepkeys_true_names = Set(names(combine(gdf, nrow, keepkeys = true)))
+                petal_length_mean =
+                    sort(compute(combine(gdf, :petal_length => mean)), :petal_length_mean)[
+                        :,
+                        :petal_length_mean,
+                    ]
+                petal_length_mean = map(m -> round(m, digits = 2), petal_length_mean)
+                temp = combine(gdf, :petal_length => mean, renamecols = false)
+                temp_names = Set(names(temp))
+                temp_petal_length = sort(compute(temp)[:, :petal_length])
+                temp_petal_length = map(l -> round(l, digits = 2), temp_petal_length)
 
-                # # Assert
-                # @test gdf_select_size == (900, 6)
+                # Assert
+                @test gdf_select_size == (900, 6)
                 @test gdf_transform_size == (900, 6)
-                # @test gdf_subset_nrow == 474
-                # @test gdf_select_plf_square_add == 163.32
-                # @test gdf_select_filter_length == 42
+                @test gdf_subset_nrow == 474
+                @test gdf_select_plf_square_add == 163.32
+                @test gdf_select_filter_length == 42
                 @test gdf_transform_length == 18
-                # @test gdf_subset_row5 == [4.6, 3.1, 1.5, 0.2, "species_4"]
-                # @test gdf_subset_row333 == [6.7, 2.5, 5.8, 1.8, "species_18"]
-                # @test gdf_subset_row474 == [7.9, 3.8, 6.4, 2.0, "virginica"]
+                @test gdf_subset_row5 == [4.6, 3.1, 1.5, 0.2, "species_4"]
+                @test gdf_subset_row333 == [6.7, 2.5, 5.8, 1.8, "species_18"]
+                @test gdf_subset_row474 == [7.9, 3.8, 6.4, 2.0, "virginica"]
 
-                # # Combine
-                # # @test gdf_keepkeys_false_names == ["nrow"]
-                # @test gdf_keepkeys_true_names == Set(["nrow", "species"])
-                # @test petal_length_mean == [
-                #     1.46,
-                #     1.46,
-                #     1.46,
-                #     1.46,
-                #     1.46,
-                #     1.46,
-                #     4.26,
-                #     4.26,
-                #     4.26,
-                #     4.26,
-                #     4.26,
-                #     4.26,
-                #     5.55,
-                #     5.55,
-                #     5.55,
-                #     5.55,
-                #     5.55,
-                #     5.55,
-                # ]
-                # @test temp_names == Set(["petal_length", "species"])
-                # @test temp_petal_length == [
-                #     1.46,
-                #     1.46,
-                #     1.46,
-                #     1.46,
-                #     1.46,
-                #     1.46,
-                #     4.26,
-                #     4.26,
-                #     4.26,
-                #     4.26,
-                #     4.26,
-                #     4.26,
-                #     5.55,
-                #     5.55,
-                #     5.55,
-                #     5.55,
-                #     5.55,
-                #     5.55,
-                # ]
+                # Combine
+                # @test gdf_keepkeys_false_names == ["nrow"]
+                @test gdf_keepkeys_true_names == Set(["nrow", "species"])
+                @test petal_length_mean == [
+                    1.46,
+                    1.46,
+                    1.46,
+                    1.46,
+                    1.46,
+                    1.46,
+                    4.26,
+                    4.26,
+                    4.26,
+                    4.26,
+                    4.26,
+                    4.26,
+                    5.55,
+                    5.55,
+                    5.55,
+                    5.55,
+                    5.55,
+                    5.55,
+                ]
+                @test temp_names == Set(["petal_length", "species"])
+                @test temp_petal_length == [
+                    1.46,
+                    1.46,
+                    1.46,
+                    1.46,
+                    1.46,
+                    1.46,
+                    4.26,
+                    4.26,
+                    4.26,
+                    4.26,
+                    4.26,
+                    4.26,
+                    5.55,
+                    5.55,
+                    5.55,
+                    5.55,
+                    5.55,
+                    5.55,
+                ]
             end
         end
     end

--- a/BanyanDataFrames/test/test_io.jl
+++ b/BanyanDataFrames/test/test_io.jl
@@ -8,7 +8,7 @@ function upload_iris_all_formats_to_s3(bucket_name)
         "iris.csv",
         iris_download_path,
     )
-    #df = collect(read_csv("s3://$(bucket_name)/iris.csv"))
+    #df = Base.collect(read_csv("s3://$(bucket_name)/iris.csv"))
     # Parquet
     Parquet.write_parquet("iris.parquet", df)
     verify_file_in_s3(
@@ -37,9 +37,9 @@ end
             iris = read_func("s3://$(bucket)/iris.$(filetype)")
             @test nrow(iris) == 150
             @test ncol(iris) == 5
-            @test collect(names(iris)) ==
+            @test Base.collect(names(iris)) ==
                 ["sepal_length", "sepal_width", "petal_length", "petal_width", "species"]
-            @test collect(propertynames(iris)) ==
+            @test Base.collect(propertynames(iris)) ==
                 [:sepal_length, :sepal_width, :petal_length, :petal_width, :species]
             iris_filter = iris[map(sl -> sl == 5.1, iris[:, :sepal_length]), :]
             iris_filter_first_row = first(compute(iris_filter))

--- a/BanyanDataFrames/test/test_medium_dataset.jl
+++ b/BanyanDataFrames/test/test_medium_dataset.jl
@@ -18,12 +18,12 @@
 #         @test nrow(tripdata) == 10906858
 #         @test ncol(tripdata) == 19
 #         @test size(tripdata) == (10906858, 19)
-#         @test collect(names(tripdata))[1] == "VendorID"
-#         @test collect(propertynames(tripdata))[1] == :VendorID
+#         @test Base.collect(names(tripdata))[1] == "VendorID"
+#         @test Base.collect(propertynames(tripdata))[1] == :VendorID
 
 #         # Get all trips with distance longer than 1.0, group by passenger count,
 #         # and get the average trip distance for each group
-#         distances = collect(
+#         distances = Base.collect(
 #             sort(
 #                 combine(
 #                     groupby(
@@ -65,7 +65,7 @@
 #         setindex!(tripdata, :start_hour, map(t -> hour(t), tripdata[:, :start_time]))
 #         tripdata_grouped = groupby(tripdata, :start_hour)
 #         means = combine(tripdata_grouped, :trip_distance => mean)
-#         means_sorted = collect(sort(means, :trip_distance_mean))
+#         means_sorted = Base.collect(sort(means, :trip_distance_mean))
 #         @test round.(means_sorted[:, :trip_distance_mean], digits = 3) == [
 #             2.523,
 #             2.529,
@@ -131,9 +131,9 @@
 #         ]
 #         @test nrow(tripdata_unique_start) == 2368616
 #         @test nrow(tripdata_unique_start_end_of_month) == 163601
-#         unique_start_sum = collect(round(sum(tripdata_unique_start_end_of_month)))
+#         unique_start_sum = Base.collect(round(sum(tripdata_unique_start_end_of_month)))
 #         @test unique_start_sum == 490661
-#         pickup_res = collect(tripdata_unique_start_end_of_month[:, :tpep_pickup_datetime])
+#         pickup_res = Base.collect(tripdata_unique_start_end_of_month[:, :tpep_pickup_datetime])
 #         @test pickup_res[1] == "2016-01-30 00:00:01"
 #         @test pickup_res[2] == "2016-01-30 00:00:02"
 #         @test pickup_res[163593] == "2016-01-31 23:57:26"
@@ -173,8 +173,8 @@
 #             :trip_distance_normalized_mean,
 #         )
 
-#         result_1 = collect(result_1)
-#         result_2 = collect(result_2)
+#         result_1 = Base.collect(result_1)
+#         result_2 = Base.collect(result_2)
 #         @test round.(result_1[:, :trip_distance_normalized_mean], digits = 3) ==
 #               round.(result_2[:, :trip_distance_normalized_mean], digits = 3) ==
 #               [0.0, 0.0, 0.0, 0.013, 0.021, 0.031, 0.042, 0.112, 0.146, 0.181]
@@ -206,9 +206,9 @@
 #         )
 #         write_csv(res_2, "s3://$(bucket)/tripdata_new.csv")
 
-#         @test sort(collect(combine(groupby(res, :passenger_count), nrow))[:, :nrow]) ==
+#         @test sort(Base.collect(combine(groupby(res, :passenger_count), nrow))[:, :nrow]) ==
 #               [3, 6, 11, 69, 53536, 88698, 109032, 149283, 403749, 1813376]
-#         @test sort(collect(combine(groupby(res_2, :day)))[:, :day]) == [
+#         @test sort(Base.collect(combine(groupby(res_2, :day)))[:, :day]) == [
 #             120,
 #             2477,
 #             25868,

--- a/BanyanDataFrames/test/test_small_dataset.jl
+++ b/BanyanDataFrames/test/test_small_dataset.jl
@@ -522,7 +522,7 @@
 #         # and compute number of rows. Sort by number of rows.
 #         iris = innerjoin(iris, iris[:, [:species]], on = :species)
 #         iris[:, :sepal_length_function] = map(sl -> round(sl), iris[:, :sepal_length])
-#         iris_sepal_length_groups = write_to_disk(
+#         iris_sepal_length_groups = compute_inplace(
 #             sort(
 #                 combine(
 #                     groupby(

--- a/BanyanDataFrames/test/test_small_dataset.jl
+++ b/BanyanDataFrames/test/test_small_dataset.jl
@@ -29,7 +29,7 @@
 #         iris = read_csv("s3://$(bucket)/iris_large.csv")
 
 #         # Select rows that have a thin petal (i.e., length > 4 * width). Select only the petal columns.
-#         res = collect(
+#         res = Base.collect(
 #             sort(
 #                 iris[
 #                     map(
@@ -49,9 +49,9 @@
 #         @test res[36, 2] == 0.2
 #         @test res[44, 1] == 1.3
 #         res_row_1 = res[256, [1, 2]]
-#         @test collect(res_row_1) == [1.9, 0.4]
+#         @test Base.collect(res_row_1) == [1.9, 0.4]
 #         res_row_2 = res[nrow(res), [1, 2]]
-#         @test collect(res_row_2) == [4.1, 1.0]
+#         @test Base.collect(res_row_2) == [4.1, 1.0]
 #     end
 
 #     run_with_session("Filtering small dataset") do session
@@ -62,12 +62,12 @@
 #         # Filter
 #         iris_filtered =
 #             sort(filter(row -> (row.sepal_length > 5.0 && row.sepal_width < 3.0), iris))
-#         iris_filtered_collect = collect(iris_filtered)
+#         iris_filtered_collect = Base.collect(iris_filtered)
 #         @test nrow(iris_filtered) == 306
 #         @test iris_filtered_collect[1, :sepal_width] == 2.5
 #         @test iris_filtered_collect[46, :petal_length] == 3.9
 #         @test iris_filtered_collect[51, :sepal_length] == 5.6
-#         @test collect(iris_filtered_collect[298, :]) == [7.7, 2.6, 6.9, 2.3, "species_6"]
+#         @test Base.collect(iris_filtered_collect[298, :]) == [7.7, 2.6, 6.9, 2.3, "species_6"]
 
 #         # Unique
 #         @test nrow(unique(iris[:, [:species]])) == 18
@@ -79,49 +79,49 @@
 
 #         # Nonunique before aggregation
 #         nonunique_idxs = nonunique(iris)
-#         nonunique_iris = collect(sort(iris[nonunique_idxs, :]))
-#         @show collect(iris[nonunique_idxs, :])
+#         nonunique_iris = Base.collect(sort(iris[nonunique_idxs, :]))
+#         @show Base.collect(iris[nonunique_idxs, :])
 #         @show nonunique_iris
 #         @show iris
 #         @show typeof(iris)
-#         @show collect(iris)
-#         @show collect(nonunique_idxs)
-#         @test collect(first(nonunique_iris)) == [4.9, 3.1, 1.5, 0.1, "setosa"]
-#         @test collect(nonunique_iris[10, :]) == [4.9, 3.1, 1.5, 0.1, "species_4"]
-#         @test collect(last(nonunique_iris)) == [5.8, 2.7, 5.1, 1.9, "virginica"]
-#         nonunique_species = collect(nonunique(iris, :species))
+#         @show Base.collect(iris)
+#         @show Base.collect(nonunique_idxs)
+#         @test Base.collect(first(nonunique_iris)) == [4.9, 3.1, 1.5, 0.1, "setosa"]
+#         @test Base.collect(nonunique_iris[10, :]) == [4.9, 3.1, 1.5, 0.1, "species_4"]
+#         @test Base.collect(last(nonunique_iris)) == [5.8, 2.7, 5.1, 1.9, "virginica"]
+#         nonunique_species = Base.collect(nonunique(iris, :species))
 #         @test sum(nonunique_species) == 882
 
 #         # Nonunique after aggregation
-#         @test collect(sum(nonunique_idxs)) == 18
-#         # @show collect(sum(nonunique_idxs))
+#         @test Base.collect(sum(nonunique_idxs)) == 18
+#         # @show Base.collect(sum(nonunique_idxs))
 #         # @show sample(nonunique_idxs)
-#         # @show collect(nonunique_idxs)
-#         nonunique_iris = collect(sort(iris[nonunique_idxs, :]))
-#         @show collect(iris[nonunique_idxs, :])
+#         # @show Base.collect(nonunique_idxs)
+#         nonunique_iris = Base.collect(sort(iris[nonunique_idxs, :]))
+#         @show Base.collect(iris[nonunique_idxs, :])
 #         @show nonunique_iris
-#         @show collect(iris)
-#         @show collect(nonunique_idxs)
-#         @test collect(first(nonunique_iris)) == [4.9, 3.1, 1.5, 0.1, "setosa"]
-#         @test collect(nonunique_iris[10, :]) == [4.9, 3.1, 1.5, 0.1, "species_4"]
-#         @test collect(last(nonunique_iris)) == [5.8, 2.7, 5.1, 1.9, "virginica"]
-#         nonunique_species = collect(nonunique(iris, :species))
+#         @show Base.collect(iris)
+#         @show Base.collect(nonunique_idxs)
+#         @test Base.collect(first(nonunique_iris)) == [4.9, 3.1, 1.5, 0.1, "setosa"]
+#         @test Base.collect(nonunique_iris[10, :]) == [4.9, 3.1, 1.5, 0.1, "species_4"]
+#         @test Base.collect(last(nonunique_iris)) == [5.8, 2.7, 5.1, 1.9, "virginica"]
+#         nonunique_species = Base.collect(nonunique(iris, :species))
 #         @test sum(nonunique_species) == 882
 
 #         # Nonunique after _another_ aggregation
-#         @test collect(sum(nonunique_idxs)) == 18
-#         # @show collect(sum(nonunique_idxs))
+#         @test Base.collect(sum(nonunique_idxs)) == 18
+#         # @show Base.collect(sum(nonunique_idxs))
 #         # @show sample(nonunique_idxs)
-#         # @show collect(nonunique_idxs)
-#         nonunique_iris = collect(sort(iris[nonunique_idxs, :]))
-#         @show collect(iris[nonunique_idxs, :])
+#         # @show Base.collect(nonunique_idxs)
+#         nonunique_iris = Base.collect(sort(iris[nonunique_idxs, :]))
+#         @show Base.collect(iris[nonunique_idxs, :])
 #         @show nonunique_iris
-#         @show collect(iris)
-#         @show collect(nonunique_idxs)
-#         @test collect(first(nonunique_iris)) == [4.9, 3.1, 1.5, 0.1, "setosa"]
-#         @test collect(nonunique_iris[10, :]) == [4.9, 3.1, 1.5, 0.1, "species_4"]
-#         @test collect(last(nonunique_iris)) == [5.8, 2.7, 5.1, 1.9, "virginica"]
-#         nonunique_species = collect(nonunique(iris, :species))
+#         @show Base.collect(iris)
+#         @show Base.collect(nonunique_idxs)
+#         @test Base.collect(first(nonunique_iris)) == [4.9, 3.1, 1.5, 0.1, "setosa"]
+#         @test Base.collect(nonunique_iris[10, :]) == [4.9, 3.1, 1.5, 0.1, "species_4"]
+#         @test Base.collect(last(nonunique_iris)) == [5.8, 2.7, 5.1, 1.9, "virginica"]
+#         nonunique_species = Base.collect(nonunique(iris, :species))
 #         @test sum(nonunique_species) == 882
 
 #         # Dropmissing, allowmissing, disallowmissing
@@ -133,8 +133,8 @@
 #         #iris_cleaned = dropmissing(iris_allowmissing)
 #         #iris_cleaned = disallowmissing(iris_cleaned)
 #         #@test nrow(iris_cleaned) == 147
-#         #@test collect(iris_cleaned[123, :])[:sepal_length] == 6.7
-#         #iris_cleaned = collect(iris_cleaned)
+#         #@test Base.collect(iris_cleaned[123, :])[:sepal_length] == 6.7
+#         #iris_cleaned = Base.collect(iris_cleaned)
 #         #@test first(iris_cleaned)[:sepal_width] == 3.0
 #         #@test last(iris_cleaned)[:petal_width] == 2.3
 #     end
@@ -148,8 +148,8 @@
 #         iris_sorted = sort(iris, :sepal_width)
 #         iris_sorted_reverse = sort(iris, :sepal_width, rev = true)
 
-#         iris_sorted = collect(iris_sorted)
-#         iris_sorted_reverse = collect(iris_sorted_reverse)
+#         iris_sorted = Base.collect(iris_sorted)
+#         iris_sorted_reverse = Base.collect(iris_sorted_reverse)
 
 #         @test iris_sorted[[1, 142, nrow(iris_sorted)], [:sepal_width, :petal_length]] ==
 #               DataFrames.DataFrame(:sepal_width => [2.0, 2.6, 4.4], :petal_length => [3.5, 4.0, 1.5])
@@ -171,9 +171,9 @@
 #         gdf_species = groupby(iris_new, :species)
 #         gdf_region = groupby(iris_new, :region)
 
-#         gr_cols = collect(groupcols(gdf_region))
-#         gs_cols = collect(groupcols(gdf_species))
-#         vr_cols = Set(collect(valuecols(gdf_region)))
+#         gr_cols = Base.collect(groupcols(gdf_region))
+#         gs_cols = Base.collect(groupcols(gdf_species))
+#         vr_cols = Set(Base.collect(valuecols(gdf_region)))
 
 #         @test gr_cols == [:region]
 #         @test gs_cols == [:species]
@@ -181,11 +181,11 @@
 #               Set([:sepal_length, :sepal_width, :petal_length, :petal_width, :species])
 
 #         lengths_species =
-#             collect(sort(combine(gdf_species, :petal_length => mean), :petal_length_mean))
-#         counts_species = collect(sort(combine(gdf_region, nrow), :region))
+#             Base.collect(sort(combine(gdf_species, :petal_length => mean), :petal_length_mean))
+#         counts_species = Base.collect(sort(combine(gdf_region, nrow), :region))
 #         lengths_region =
-#             collect(sort(combine(gdf_region, :petal_length => mean), :petal_length_mean))
-#         counts_region = collect(sort(combine(gdf_region, nrow), :region))
+#             Base.collect(sort(combine(gdf_region, :petal_length => mean), :petal_length_mean))
+#         counts_region = Base.collect(sort(combine(gdf_region, nrow), :region))
 
 #         @test lengths_species[:, :petal_length_mean] ==
 #               lengths_region[:, :petal_length_mean] ==
@@ -228,11 +228,11 @@
 #             select(gdf, :, [:petal_length] => (pl) -> pl .- mean(pl)),
 #             :petal_length_function,
 #         )
-#         petal_length_function_sum = round(collect(reduce(-, iris_select[:, :petal_length_function])), digits=2)
+#         petal_length_function_sum = round(Base.collect(reduce(-, iris_select[:, :petal_length_function])), digits=2)
 #         @test petal_length_function_sum == -52.71
         
 #         #@test round.(
-#         #    collect(
+#         #    Base.collect(
 #         #        iris_select[:, :petal_length_function][[1, 7488, 34992, nrow(iris_select)]],
 #         #    ),
 #         #    digits = 3,
@@ -240,7 +240,7 @@
 
 #         # Transform
 #         iris_new = transform(gdf, :species => x -> "iris-" .* x)
-#         species_names = collect(sort(unique(iris_new[:, "species_function"])))
+#         species_names = Base.collect(sort(unique(iris_new[:, "species_function"])))
 #         @test species_names == [
 #             "iris-setosa",
 #             "iris-species_10",
@@ -264,7 +264,7 @@
 
 #         # Split-Apply-Combine
 #         iris_mins =
-#             collect(sort(combine(gdf, :petal_length => minimum), :petal_length_minimum))
+#             Base.collect(sort(combine(gdf, :petal_length => minimum), :petal_length_minimum))
 #         @test iris_mins[:, :petal_length_minimum] == [
 #             1.0,
 #             1.0,
@@ -329,8 +329,8 @@
 #                 nrow,
 #             ),
 #         )
-#         long_petal_iris_nrow = collect(long_petal_iris)[:, :nrow]
-#         long_petal_iris_species = collect(long_petal_iris)[:, :species]
+#         long_petal_iris_nrow = Base.collect(long_petal_iris)[:, :nrow]
+#         long_petal_iris_species = Base.collect(long_petal_iris)[:, :species]
 #         @test long_petal_iris_nrow == [
 #             1250,
 #             1250,
@@ -378,8 +378,8 @@
 #         # upload_iris_to_s3(bucket)
 #         iris = read_csv("s3://$(bucket)/iris_large.csv")
 #         gdf = groupby(iris, :species)
-#         lengths = collect(sort(combine(gdf, :petal_length => mean)))
-#         counts = collect(combine(gdf, nrow))
+#         lengths = Base.collect(sort(combine(gdf, :petal_length => mean)))
+#         counts = Base.collect(combine(gdf, nrow))
 
 #         @show lengths
 #         @show counts
@@ -457,10 +457,10 @@
 #             "region",
 #         ])
 #         @test nrow(iris_joined) == 146
-#         res = collect(iris_joined)
-#         @test collect(res[1, :]) == [4.3, 3.0, 1.1, 0.1, "setosa", 1.0, "Arctic"]
-#         @test collect(res[121, :]) == [6.6, 2.9, 4.6, 1.3, "species_5", 5.0, "region_5"]
-#         @test collect(res[146, :]) == [7.9, 3.8, 6.4, 2.0, "species_6", 6.0, "region_6"]
+#         res = Base.collect(iris_joined)
+#         @test Base.collect(res[1, :]) == [4.3, 3.0, 1.1, 0.1, "setosa", 1.0, "Arctic"]
+#         @test Base.collect(res[121, :]) == [6.6, 2.9, 4.6, 1.3, "species_5", 5.0, "region_5"]
+#         @test Base.collect(res[146, :]) == [7.9, 3.8, 6.4, 2.0, "species_6", 6.0, "region_6"]
 #     end
 # end
 
@@ -499,8 +499,8 @@
 
 #         @test nrow(result_1) == nrow(result_2) == 462
 
-#         result_1 = collect(result_1)
-#         result_2 = collect(result_2)
+#         result_1 = Base.collect(result_1)
+#         result_2 = Base.collect(result_2)
 
 #         @test isapprox(result_1[7, :petal_length_normalized], 0.52380, atol = 1e-4)
 #         @test isapprox(result_2[7, :petal_length_normalized], 0.52380, atol = 1e-4)
@@ -534,7 +534,7 @@
 #                 :nrow,
 #             ),
 #         )
-#         res = collect(iris_sepal_length_groups)
+#         res = Base.collect(iris_sepal_length_groups)
 #         @test res[:, :nrow] == [1500, 1800, 7200, 14100, 20400]
 #         @test res[:, :sepal_length_rounded] == [4.0, 8.0, 7.0, 5.0, 6.0]
 #     end

--- a/BanyanDataFrames/test/utils_data.jl
+++ b/BanyanDataFrames/test/utils_data.jl
@@ -238,9 +238,9 @@ function setup_stress_tests(bucket_name=get_cluster_s3_bucket_name())
             for ncopy = 1:n_repeats
                 dst_path = "s3://$(bucket_name)/tripdata_large_$(filetype).$(filetype)/tripdata_$(month)_copy$(ncopy).$(filetype)"
                 dst_s3_path = S3Path(dst_path, config = Banyan.get_aws_config())
-                append!(dst_s3_paths, dst_s3_path)
+                push!(dst_s3_paths, dst_s3_path)
                 if !isfile(dst_s3_path)
-                    append!(dst_s3_paths_missing, dst_s3_path)
+                    push!(dst_s3_paths_missing, dst_s3_path)
                 end
             end
         end

--- a/BanyanImages/src/locations.jl
+++ b/BanyanImages/src/locations.jl
@@ -156,7 +156,7 @@ function RemoteImageSource(remotepath; shuffled=false, source_invalid = false, s
             # In this case, read one random file to collect metadata
             # We assume that all files have the same nbytes and ndims
 
-            filep = collect(Iterators.take(Iterators.reverse(files_to_read_from), 1))[1]
+            filep = Base.collect(Iterators.take(Iterators.reverse(files_to_read_from), 1))[1]
             p = download_remote_path(filep)
             with_downloaded_path_for_reading(p) do pp
 

--- a/BanyanONNXRunTime/src/onnxruntime.jl
+++ b/BanyanONNXRunTime/src/onnxruntime.jl
@@ -43,7 +43,7 @@ function (is::InferenceSession)(inputs, output_names=nothing)
         if dynamic_axis
             res = first(values(is(Dict(input_name  => A))))
         else
-            res = Base.mapslices(arr -> first(values(is(Dict(input_name => arr)))), A, dims=collect(2:ndims(A)))
+            res = Base.mapslices(arr -> first(values(is(Dict(input_name => arr)))), A, dims=Base.collect(2:ndims(A)))
         end
         res_size = Base.size(res)
     end


### PR DESCRIPTION
This PR introduces several new features!

1. Ranges for collecting Julia ranges into Banyan Julia arrays (e.g., `BanyanArrays.collect(1:10:10_000_000)`)
2. `getindex` for indexing Banyan arrays (e.g., `array[:, :, [2, 6], 1:10]`)
3. `compute_inplace` for computing some value without returning it to the client side (e.g., `compute_inplace(results)`

We also fixed some bugs in the annotation of `map` and the implementation of `Copy*` PFs.